### PR TITLE
Fix rails commands for windows

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -54,7 +54,7 @@ mkdir projects
 cd projects
 rails new railsgirls
 cd railsgirls
-ruby script\rails server
+rails server
 {% endhighlight %}
   </div>
 </div>
@@ -84,9 +84,9 @@ rails server
 
   <div class="win">
 {% highlight sh %}
-ruby rails generate scaffold idea name:string description:text picture:string
-ruby rake db:migrate
-ruby rails\server
+rails generate scaffold idea name:string description:text picture:string
+rake db:migrate
+rails server
 {% endhighlight %}
   </div>
 </div>

--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -37,8 +37,6 @@ rails serverを起動したりコマンドを実行したりするものです�
 
 そして、Terminal上で次のコマンドを入力します。 :
 
-<div class="os-specific">
-  <div class="nix">
 {% highlight sh %}
 mkdir projects
 cd projects
@@ -46,18 +44,6 @@ rails new railsgirls
 cd railsgirls
 rails server
 {% endhighlight %}
-  </div>
-
-  <div class="win">
-{% highlight sh %}
-mkdir projects
-cd projects
-rails new railsgirls
-cd railsgirls
-rails server
-{% endhighlight %}
-  </div>
-</div>
 
 自分のパソコン上のブラウザで [http://localhost:3000](http://localhost:3000) にアクセスしてください。
 
@@ -73,23 +59,11 @@ Rails の scaffold 機能を使って、list, add, remove, edit, view を生成�
 
 **Coachより:** scaffold とはなんでしょう？ (コマンドの説明をしてください。1. ただのコマンド, 2. モデル名でDBテーブルと関係があるもの;命名規約, 3. 属性や型) また、migration 機能が何で、なぜ必要なのか。
 
-<div class="os-specific">
-  <div class="nix">
 {% highlight sh %}
 rails generate scaffold idea name:string description:text picture:string
 rake db:migrate
 rails server
 {% endhighlight %}
-  </div>
-
-  <div class="win">
-{% highlight sh %}
-rails generate scaffold idea name:string description:text picture:string
-rake db:migrate
-rails server
-{% endhighlight %}
-  </div>
-</div>
 
 ブラウザで [http://localhost:3000/ideas](http://localhost:3000/ideas) にアクセスしてください。
 


### PR DESCRIPTION
チュートリアル(http://railsgirls.jp/app/ ）の中に、Windowsと他環境で実行するコマンドを切り替えて表示する部分2ヶ所について、Windowsでの実行するコマンドを修正しました。
（Windows7 64bitで実行してブラウザで正しく表示できることを確認しました。RubyやRailsなどのバージョンは下に載せます。）
修正した結果、他環境のコマンドと同じになったので、1つにまとめました。
それぞれの修正でコミットが分かれています。

Windowsのコマンドをチェックした環境は次のとおりです。

<pre>
C:\Users\yoiz\Desktop\rails-test\demo>ruby -v
ruby 1.9.3p392 (2013-02-22) [i386-mingw32]

C:\Users\yoiz\Desktop\rails-test\demo>gem -v
1.8.24

C:\Users\yoiz\Desktop\rails-test\demo>rails -v
Rails 3.2.13
</pre>


（ところで、bundle installしたらkramdown gemがインストールされたのですが、コミットログを見る限りredcarpetに切り替えたようなので不要に思います。kramdownがインストールされるのはGemfile.lockに書いてあるからですかね？）
