### PR TITLE
Remove unnecessary back slash about rails_12factor

### DIFF
--- a/_posts/2012-04-19-heroku.markdown
+++ b/_posts/2012-04-19-heroku.markdown
@@ -54,7 +54,7 @@ to
 {% highlight ruby %}
 group :production do
   gem 'pg'
-  gem 'rails\_12factor'
+  gem 'rails_12factor'
 end
 {% endhighlight %}
 


### PR DESCRIPTION
今日のrails girls kyoto moreで
http://railsgirls.jp/heroku/
を進めていると不要と思われるバックスラッシュがありました（外して手順を進めるとうまくいきました）
