### PR TITLE
Add a sentence about executing bundle install.

### DIFF
--- a/_posts/2012-04-19-heroku.markdown
+++ b/_posts/2012-04-19-heroku.markdown
@@ -58,6 +58,8 @@ group :production do
 end
 {% endhighlight %}
 
+もう一度、 `bundle install --without production` を実行してセットアップしてください。
+
 __COACHより__: Heroku におけるログの仕組みについて調べてみましょう。
 
 #### バージョン管理(git)


### PR DESCRIPTION
本日のrails girls kyoto moreにて上手くいきませんでした。
このタイミングでもう一度`bundle install`する必要があります。

先の`pg`に関する部分での`bundle install`をやめても良いのですが、
rails3で実施する場合の事を考え、この一文を追加した方が良いのではと考えました(まるっとrails_12factor入れない場合)。
