### PR TITLE
Fix wrong commands for Windows

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -84,8 +84,8 @@ rails server
 
   <div class="win">
 {% highlight sh %}
-ruby rails generate scaffold idea name:string description:text picture:string
-ruby rake db:migrate
+ruby bin\rails generate scaffold idea name:string description:text picture:string
+rake db:migrate
 ruby bin\rails server
 {% endhighlight %}
   </div>


### PR DESCRIPTION
ruby の実行をコマンドに含める場合、bin\rails への対応が漏れている箇所があったので修正しました。
rake については (06f0570 で一度 revert されているのは確認したのですが、) そのままでは「ruby: No such file or directory -- rake (LoadError)」となるため、改めて修正してみました。

問題ないようであれば取り込んでやってくださいませ。
