### PR TITLE
Add "Rails チュートリアル" to "書籍 (日本語)"

### DIFF
--- a/_posts/2013-04-08-how-to-continue-with-programming.markdown
+++ b/_posts/2013-04-08-how-to-continue-with-programming.markdown
@@ -43,7 +43,7 @@ and was published on
 
 ### 書籍（日本語）
 
-* [Railsチュートリアル](http://railstutorial.jp/) - 先ほど紹介した書籍の日本語版です。原著と同様に、HTML ならば無料、電子書籍ならば有料となっています。Rails3.2とRails 4.0に対応しています。
+* [Railsチュートリアル](http://railstutorial.jp/) - 先ほど紹介した書籍の日本語訳です。原著と同様に、HTML ならば無料、電子書籍ならば有料となっています。Rails3.2とRails 4.0に対応。
 
 * [HerokuではじめるRailsプログラミング入門](http://www.amazon.co.jp/dp/4797371838) - Rails初心者向けの書籍です。簡単なWebアプリケーションをつくり、Herokuにデプロイする手順を丁寧に解説しています。
 

--- a/_posts/2013-04-08-how-to-continue-with-programming.markdown
+++ b/_posts/2013-04-08-how-to-continue-with-programming.markdown
@@ -43,6 +43,8 @@ and was published on
 
 ### 書籍（日本語）
 
+* [Railsチュートリアル](http://railstutorial.jp/) - 先ほど紹介した書籍の日本語版です。原著と同様に、HTML ならば無料、電子書籍ならば有料となっています。Rails3.2とRails 4.0に対応しています。
+
 * [HerokuではじめるRailsプログラミング入門](http://www.amazon.co.jp/dp/4797371838) - Rails初心者向けの書籍です。簡単なWebアプリケーションをつくり、Herokuにデプロイする手順を丁寧に解説しています。
 
 * [改訂新版 基礎Ruby on Rails](http://www.amazon.co.jp/dp/4844331566) - Rails初心者向けの分かり易い入門書です。Rails3.2対応。


### PR DESCRIPTION
[Rails Tutorial](http://ruby.railstutorial.org/) の日本語訳が完了したので、日本語訳のサイトを追加しました。`Rails Tutorial` の日本語訳であることが分かりやすくなるように、`Rails Tutorial` の紹介の直後に挿入しましたが、もしリストの順序に制約などがありましたら、ご自由に変えて頂いて構いません。

よろしくお願いします。
