### PR TITLE
Migrate to bootstrap version 3

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -124,7 +124,8 @@ ruby bin\rails server
 この1行前に次のタグを追記してください。
 
 {% highlight erb %}
-<link rel="stylesheet" href="http://railsgirls.com/assets/bootstrap.css">
+<link rel="stylesheet" href="//assets/bootstrap.css" />
+<link rel="stylesheet" href="//assets/bootstrap-theme.css" />
 {% endhighlight %}
 
 そして、この部分、
@@ -144,16 +145,24 @@ ruby bin\rails server
 次に、ナビゲーションバーとフッターをレイアウトに追加してみましょう。同じファイルの`<body>`の直後に以下を追加してください。
 
 {% highlight html %}
-<div class="navbar navbar-fixed-top">
-  <div class="navbar-inner">
-    <div class="container">
-      <a class="brand" href="/">The Idea app</a>
-      <ul class="nav">
+<nav class="navbar navbar-default navbar-fixed-top" role="navigation">
+  <div class="container">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="/">The Idea app</a>
+    </div>
+    <div class="collapse navbar-collapse">
+      <ul class="nav navbar-nav">
         <li class="active"><a href="/ideas">Ideas</a></li>
       </ul>
     </div>
   </div>
-</div>
+</nav>
 {% endhighlight %}
 
 さらに、`</body>` の直前に以下を追加してください。
@@ -164,6 +173,7 @@ ruby bin\rails server
     Rails Girls 2013
   </div>
 </footer>
+<script src="//railsgirls.com/assets/bootstrap.js"></script>
 {% endhighlight %}
 
 ここで、ideasの表のスタイルも変更してみましょう。`app/assets/stylesheets/application.css` を開いて、コードの一番下に次のcssを追加しましょう。


### PR DESCRIPTION
`2012-04-18-app.markdown` の説明を bootstrap バージョン3に移行させます。
本家の方にも同様の pull-request を提出してあります (railsgirls/railsgirls.github.com/pull/130)。
この変更は、本家が bootstrap バージョン3の関連ファイルを `railsgirls.com` の `assets` ディレクトリに配置しないと適用できないため、本家の方の pull-request が無事に採用された場合だけ採用してください。
