### PR TITLE
Add installing ruby in OSX 10.9 Mavericks.

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -38,7 +38,7 @@ Appleメニューをクリックして *About This Mac* (図 1) を選びます�
 
 図 2
 
-**ステップ 3.** 使用している OS Xのバージョン用 RailsInstaller ダウンロードします。
+**ステップ 3-A.** 使用している OS Xのバージョン用 RailsInstaller ダウンロードします。(OS X10.6, 10.7, 10.8の場合)
 
 * [10.7, 10.8 用 RailsInstaller](http://railsinstaller.s3.amazonaws.com/RailsInstaller-1.0.4-osx-10.7.app.tgz) <span class="muted">(325MB)</span>
 * [10.6 用 RailsInstaller](http://railsinstaller.s3.amazonaws.com/RailsInstaller-1.0.4-osx-10.6.app.tgz) <span class="muted">(224MB)</span>
@@ -59,6 +59,60 @@ Rails アプリを作成するコマンドを実行してインストールと R
 {% highlight sh %}
 rails new railsgirls
 {% endhighlight %}
+
+**ステップ 3-B.** rbenv を使って Ruby と Ruby on Rails をインストール(OS X 10.9の場合):
+
+OS X 10.9 の場合は、Homebrew と rbenv を使って環境をつくります。
+
+3-B-1. Command line tools をターミナルからインストール:
+
+{% highlight sh %}
+xcode-select --install
+{% endhighlight %}
+
+3-B-2. [Homebrew](http://brew.sh/)をインストール:
+
+{% highlight sh %}
+ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
+{% endhighlight %}
+
+3-B-3. [rbenv](https://github.com/sstephenson/rbenv)をインストール:
+
+{% highlight sh %}
+brew update
+brew install rbenv ruby-build
+echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
+echo 'export PATH="$HOME/.rbenv/shims:$PATH"' >> ~/.bash_profile
+source ~/.bash_profile
+{% endhighlight %}
+
+3-B-4. rbenvを使ってRubyをインストール:
+
+"rbenv install -l" コマンドでrbenvでインストール可能なRubyのバージョンを確認できます。
+
+{% highlight sh %}
+rbenv install 2.1.0
+{% endhighlight %}
+
+※もしも "OpenSSL::SSL::SSLError: ... : certificate verify failed" エラーが起きた場合は、以下の手順を試してみてください。
+
+{% highlight sh %}
+brew install curl-ca-bundle
+cp /usr/local/opt/curl-ca-bundle/share/ca-bundle.crt `ruby -ropenssl -e 'puts OpenSSL::X509::DEFAULT_CERT_FILE'`
+{% endhighlight %}
+
+3-B-5. デフォルトのRuby を設定:
+
+{% highlight sh %}
+rbenv global 2.1.0
+{% endhighlight %}
+
+3-B-6. Railsのインストール:
+
+{% highlight sh %}
+gem i rails
+{% endhighlight %}
+
 
 **最後のステップ** コードを編集するのに必要なテキストエディタをインストールする。
 


### PR DESCRIPTION
【連絡：本家のpull req がマージされてからマージ】
インストールページにRailsインストーラが提供されていないMavericksの場合のインストール手順を追記しました。
このpull req を取り込む前は、トラブルシューティングのページに同様の内容が書いてあるので、そちらを参照してください。
