### PR TITLE
Windowsのインストールで、Herokuを使う場合にgitとssh-keygenをインストールする必要があるという文を削除する

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -127,9 +127,7 @@ gem i rails
 ## <a id="setup_for_windows">Windows 用セットアップ</a>
 
 [RailsInstaller](https://github.com/railsinstaller/railsinstaller-windows/releases/download/2.2.2/railsinstaller-2.2.2.exe) をダウンロードして、実行します。
-インストールのオプションは全てディフォルトを選択します。
-
-[Heroku で Rails アプリを公開する](/heroku) 場合は Git と SSH-key もインストールしてください。
+インストールのオプションは全てデフォルトを選択します。
 
 もしもRailsのバージョンが最新ではない場合は、以下のコマンドを "Command Prompt with Ruby on Rails" から実行することでバージョンアップできます。
 


### PR DESCRIPTION
RailsInstaller 2.2.2 では、git（msysgit）が含まれています。また、sshの秘密・公開鍵も生成してくれます。

本家の方にもPRを出しました。（ railsgirls/railsgirls.github.com#149 ）
