### PR TITLE
GitHubのガイドで、READMEを作成するのではなく、README.rdoc を確認するようにする

### DIFF
--- a/_posts/2013-04-14-github.md
+++ b/_posts/2013-04-14-github.md
@@ -45,13 +45,22 @@ GitHubの自分のプロフィールページで、"new repo" ![screen shot 2013
 
 *メモ:*  もしすでに[Heroku guide](/heroku)の章をすませていたら、gitレポジトリの初期化は終わっています。ここは飛ばして次のステップに進んでください。
 
-次に以下の通りにタイプします:
+`README.rdoc` というファイルが、railsgirlsディレクトリに存在するか確認します:
 
-`touch README`
+<div class="os-specific">
+  <div class="nix">
+    <code>ls README.rdoc</code>
+  </div>
+  <div class="win">
+    <code>dir README.rdoc</code>
+  </div>
+</div>
 
-これで"README"と呼ばれるファイルが、自分のrailsgirlsディレクトリに作られます。
+存在しない場合は、以下の通りにタイプして、"README.rdoc" というファイルを作成します。
 
-**Coachより:** READMEについてちょっと話してください。
+`touch REAME.rdoc`
+
+**Coachより:** `README.rdoc` についてちょっと話してください。
 
 次に、以下のように入力してください:
 


### PR DESCRIPTION
（おそらく Rails 4 から）`rails new` で、`README.rdoc` が作成されるようになっています。そのため、「[GitHubに自分のアプリをPushする](http://railsgirls.jp/github/)」で、`touch README`の代わりに`ls README.rdoc`で存在を確認するようにするといいのでは？と思いました。
