### PR TITLE
Fix touch command

### DIFF
--- a/_posts/2013-04-14-github.md
+++ b/_posts/2013-04-14-github.md
@@ -83,9 +83,14 @@ dir README.rdoc
 
 存在しない場合は、以下の通りにタイプして、"README.rdoc" というファイルを作成します。
 
-{% highlight sh %}
-touch REAME.rdoc
-{% endhighlight %}
+<div class="os-specific">
+  <div class="nix">
+    <code>touch README.rdoc</code>
+  </div>
+  <div class="win">
+    <code>type nul > README.rdoc</code>
+  </div>
+</div>
 
 **Coachより:** `README.rdoc` についてちょっと話してください。
 

--- a/_posts/2013-04-14-github.md
+++ b/_posts/2013-04-14-github.md
@@ -85,10 +85,14 @@ dir README.rdoc
 
 <div class="os-specific">
   <div class="nix">
-    <code>touch README.rdoc</code>
+{% highlight sh %}
+touch README.rdoc
+{% endhighlight %}
   </div>
   <div class="win">
-    <code>type nul > README.rdoc</code>
+{% highlight sh %}
+type nul > README.rdoc
+{% endhighlight %}
   </div>
 </div>
 


### PR DESCRIPTION
Windowsにはtouchコマンドがないので、Windows用とUnix用でタイプする文言を分けました（ 16547c5 ）。
また、highlight - endhighlightで囲むようにしました （ #109 と同等です）（ a0299f5 ）。

もともとはREAME.rdocになっていた（Dが抜けている）のですが、ミススペルと考え、README.rdocとしました。
