### PR TITLE
Support bootstrap3 ( fix CSS class name ).

### DIFF
--- a/_posts/2012-11-01-devise.markdown
+++ b/_posts/2012-11-01-devise.markdown
@@ -54,10 +54,10 @@ environments ファイルにデフォルトの url オプションを定義し�
 
 {% highlight erb %}
 <% if notice %>
-  <p class="alert alert-success" role="alert"><%= notice %></p>
+  <p class="alert alert-success"><%= notice %></p>
 <% end %>
 <% if alert %>
-  <p class="alert alert-danger" role="alert"><%= alert %></p>
+  <p class="alert alert-danger"><%= alert %></p>
 <% end %>
 {% endhighlight %}
 

--- a/_posts/2012-11-01-devise.markdown
+++ b/_posts/2012-11-01-devise.markdown
@@ -54,10 +54,10 @@ environments ファイルにデフォルトの url オプションを定義し�
 
 {% highlight erb %}
 <% if notice %>
-  <p class="alert alert-notice"><%= notice %></p>
+  <p class="alert alert-success" role="alert"><%= notice %></p>
 <% end %>
 <% if alert %>
-  <p class="alert alert-error"><%= alert %></p>
+  <p class="alert alert-danger" role="alert"><%= alert %></p>
 <% end %>
 {% endhighlight %}
 


### PR DESCRIPTION
noticeやalertの指定がbootstrap2のものであり、現在使用しているbootstrap3のものではCSSが適用されないため、クラス名を変更しました。
