### PR TITLE
HomebrewのインストールURLを修正

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -77,7 +77,7 @@ xcode-select --install
 3-B-2. [Homebrew](http://brew.sh/)をインストール:
 
 {% highlight sh %}
-ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 {% endhighlight %}
 
 3-B-3. [rbenv](https://github.com/sstephenson/rbenv)をインストール:


### PR DESCRIPTION
[Homebrew](http://brew.sh/) のインストールURLが変更されていました。
http://railsgirls.jp/install/ の `3-B-2. Homebrewをインストール` の部分です :beer: 

https://github.com/railsgirls/railsgirls.github.com/pull/206
