### PR TITLE
confirm ダイアログを表示できるようにする

### DIFF
--- a/_posts/2013-01-20-design.markdown
+++ b/_posts/2013-01-20-design.markdown
@@ -109,7 +109,7 @@ idea のタイトルをクリックすると、idea の詳細画面を見るこ�
     <p><b>Description: </b><%= @idea.description %></p>
     <p>
       <%= link_to 'Edit', edit_idea_path(@idea) %> |
-      <%= link_to 'Destroy', @idea, confirm: 'Are you sure?', method: :delete %> |
+      <%= link_to 'Destroy', @idea, data: { confirm: 'Are you sure?' }, method: :delete %> |
       <%= link_to 'Back', ideas_path %>
     </p>
   </div>


### PR DESCRIPTION
今日の [Rails Girls Nagoya 第二回](http://railsgirls.com/nagoya) で @hatenacat と一緒に[アプリ](http://immense-shore-1899.herokuapp.com/)を作ったときに、破壊の確認ダイアログがちゃんと表示できませんでした。 https://github.com/hatenacat/railsgirls/commit/47586e292418748fb6a9bf8fa72bb6c0d6424056 の修正を適用したら通常に表示できるようになったので、もしかしたら Rails 3.x と Rails 4.x との違いだったかなあと思います。

ご確認の程、よろしくお願いします！

@yada-ITA @eitoball @springaki ご参考までに〜
