### PR TITLE
コードの種類を示すアイコンを復活

### DIFF
--- a/js/guides.js
+++ b/js/guides.js
@@ -27,9 +27,9 @@ function detectOs() {
 }
 
 function addIcons() {
-  $("code.sh, code.bat").closest('.highlight').before('<i class="icon-small-prompt"></i>');
-  $("code.erb, code.html, code.ruby, code.css").closest('.highlight').before('<i class="icon-small-text-editor"></i>');
-  $("code.browser").closest('.highlight').before('<i class="icon-small-browser"></i>');
+  $("code.language-sh, code.language-bat").closest('.highlight').before('<i class="icon-small-prompt"></i>');
+  $("code.language-erb, code.language-html, code.language-ruby, code.language-css").closest('.highlight').before('<i class="icon-small-text-editor"></i>');
+  $("code.language-browser").closest('.highlight').before('<i class="icon-small-browser"></i>');
 }
 
 function initializeOsSwitchers() {


### PR DESCRIPTION
ターミナル用のコマンド、テキストエディタ用のコード、などを示すアイコンを表示するjsが効いていなかったので修正しました。
## 変更前
### shell

![image](https://cloud.githubusercontent.com/assets/4459676/7362713/9e3e86d4-eda8-11e4-9d52-2798ab1e71fa.png)
### erb

![image](https://cloud.githubusercontent.com/assets/4459676/7362718/ba7c51dc-eda8-11e4-9e43-882fd0d57c85.png)
## 変更後
### shell

![image](https://cloud.githubusercontent.com/assets/4459676/7362739/f608be16-eda8-11e4-90aa-6e2641a93229.png)
### erb

![image](https://cloud.githubusercontent.com/assets/4459676/7362747/199a3cf6-eda9-11e4-8d71-bd0a0fdf99f4.png)
