### PR TITLE
Nitrous の記述を有料版向けに変更

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -24,7 +24,7 @@ rails serverを起動したりコマンドを実行したりするものです�
 
 アプリケーションを表示するためのものです。
 
-※ このガイドでは、OSごとにコマンドが違う場合に、Windows/Other の表示を切り替えています。Nitrous.IO などのクラウドサービスを利用して開発する場合は、(Windowsマシンを利用していても) Other(Linux用のコマンド)を使ってください。
+※ このガイドでは、OSごとにコマンドが違う場合に、Windows/Other の表示を切り替えています。Nitrous などのクラウドサービスを利用して開発する場合は、(Windowsマシンを利用していても) Other(Linux用のコマンド)を使ってください。
 
 ## *1.*アプリケーションを作る
 
@@ -35,7 +35,7 @@ rails serverを起動したりコマンドを実行したりするものです�
 * OS X: Spotlightで *Terminal* と入力して出てきた Terminal をクリックしてください。
 * Windows: スタートメニューをクリックして、すべてのプログラムから *RailsInstaller* を探し、*Command Prompt with Ruby on Rails*をクリックしてください。(みつからない場合は、「プログラムとファイルの検索」へ *Command Prompt with Ruby on Rails* を入力し検索してください。)
 * Linux (Ubuntu/Fedora): Dashホームで *Terminal* を探して、*Terminal* をクリックしてください。
-* クラウドサービス(Nitrous.IOなど): 作成したアカウントでログインし、box が起動した状態で IDE 画面へ移動します。(詳細は [インストール・レシピ](/install#using-a-cloud-service) を参照してください。) ターミナルはブラウザの下部に表示されます。
+* クラウドサービス(Nitrousなど): 作成したアカウントでログインし、box が起動した状態で IDE 画面へ移動します。(詳細は [インストール・レシピ](/install#using-a-cloud-service) を参照してください。) ターミナルはブラウザの下部に表示されます。
 
 そして、Terminal上で次のコマンドを入力します:
 

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -297,20 +297,29 @@ rails server
 
 ## <a id="using-a-cloud-service">クラウドサービスを利用する</a>
 
-あなたのコンピュータにRuby on Railsやエディタをインストールする代わりに、開発用のWebサービスを利用することもできます。ブラウザとネットへアクセスできる環境があればOKです。 ここでは [Nitrous.IO](https://nitrous.io) を利用する手順を説明します。もしも、別のサービスを利用している場合は、例えば 'box' の代わりに 'workspace' という単語を使うなど用語の違いがあるかもしれませんが、概ね同じになっているはずです。
+あなたのコンピュータにRuby on Railsやエディタをインストールする代わりに、開発用のWebサービスを利用することもできます。ブラウザとネットへアクセスできる環境があればOKです。 ここでは [Nitrous](https://nitrous.io) を利用する手順を説明します。もしも、別のサービスを利用している場合は、例えば 'box' の代わりに 'workspace' という単語を使うなど用語の違いがあるかもしれませんが、概ね同じになっているはずです。
+
+*オーガナイザーの方へ*:
+
+Nitrous は有料サービスですが、コミュニティで使う場合は無料で使うことができます。 メールアドレス <pro [at] nitrous.io> へ、以下の内容を添えてコミュニティ用アカウントを申請してください。
+
+- 使用者のメールアドレスのリスト
+- 使用期間
+- 使用開始日時
+- アクセス可能期間(○日間、○週間 など)
 
 ### *1.* ブラウザを確認する
 
 * Internet Explorer を利用している場合は、 [Google Chrome](https://www.google.com/intl/ja/chrome/browser/) または [Firefox](https://www.mozilla.org/ja/firefox/new/) をインストールしてください。（一部の機能がIEでは動かない場合があります。）
 
-### *2.* 無料のアカウントを作成する
+### *2.* アカウントを作成する
 
-* [https://nitrous.io](https://nitrous.io/) から無料のアカウントを作成します。
+* [https://nitrous.io](https://nitrous.io/) からアカウントを作成します。
 * ユーザーネーム、メールアドレス、パスワードを入力して、緑の 'Sign Up For Free' ボタン からアカウントを作成できます。
 
 ### *3.* Ruby on Rails の開発用に box (workspace) を設定する
 
-* [Nitrous.IO](https://nitrous.io/) の画面右上の Sign in をクリックし、作成したアカウントでログインします。緑の 'Open dashboard' ボタンをクリックし、ダッシュボード画面へ移動します。
+* [Nitrous](https://nitrous.io/) の画面右上の Sign in をクリックし、作成したアカウントでログインします。緑の 'Open dashboard' ボタンをクリックし、ダッシュボード画面へ移動します。
 
 * テンプレートから Ruby/Rails を選んで box を作ります。デフォルトのままで大丈夫ですが、もしも box の名前を変えたい場合は、変えても構いません。
 


### PR DESCRIPTION
Nitrous.io が無料サービスを閉じて、有料版のみとなりました。コミュニティで使う場合は事前の申請により無料で利用することが可能です。申請手順などを追記しました。また、Nitrous.io の記述を Nitrous に置き換えました。

有料版になってからは私はまだ利用したことがないので、利用した方は記述で相違がありましたら直していただけると嬉しいです。

参考：
- https://github.com/railsgirls/railsgirls.github.com/pull/241
- https://github.com/railsgirls/railsgirls.github.com/pull/246
