### PR TITLE
Update git cheatsheet link because original one was broken.

### DIFF
--- a/_posts/2013-04-14-github.md
+++ b/_posts/2013-04-14-github.md
@@ -168,7 +168,7 @@ git push origin master
 ### Gitについてもっと学ぶ
 
  * [trygit.org](http://try.github.io/)をチェックアウトする
- * [Git Cheatsheet](https://na1.salesforce.com/help/doc/en/salesforce_git_developer_cheatsheet.pdf)を使う
+ * [GITチートシート](https://training.github.com/kit/downloads/ja/github-git-cheat-sheet.pdf)を使う
  * [git-scm.org](http://git-scm.com/)でGitコマンドを眺めてみる
 
 


### PR DESCRIPTION
/githubの最後のチートシートがリンク切れだったので別のものにしました。ついでに日本語のチートシートにしました。
