### PR TITLE
Change CSS and JS links because https://railsgirls.com certificate was expired.

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -104,8 +104,8 @@ rails server
 この1行前に次のタグを追記してください。
 
 {% highlight erb %}
-<link rel="stylesheet" href="//railsgirls.com/assets/bootstrap.css">
-<link rel="stylesheet" href="//railsgirls.com/assets/bootstrap-theme.css">
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css">
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap-theme.min.css">
 {% endhighlight %}
 
 そして、この部分、
@@ -153,7 +153,7 @@ rails server
     Rails Girls 2015
   </div>
 </footer>
-<script src="//railsgirls.com/assets/bootstrap.js"></script>
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
 {% endhighlight %}
 
 ここで、ideasの表のスタイルも変更してみましょう。`app/assets/stylesheets/application.css` を開いて、コードの一番下に次のcssを追加しましょう。


### PR DESCRIPTION
railsgirls-jp/coach.info#8 の解決のため、2013年に証明書の切れているrailsgirls.comへのリンクを止めて他から取得するようにしました。
