### PR TITLE
Fix css file name

### DIFF
--- a/_posts/2013-01-20-design.markdown
+++ b/_posts/2013-01-20-design.markdown
@@ -26,7 +26,7 @@ body { padding-top: 100px; }
 body { padding-top: 60px; }
 {% endhighlight %}
 
-最後に `app/assets/stylesheets/scaffolds.css.scss` を削除します。これは Rails が標準で作成するファイルで私達にはもう必要の無いものです。
+最後に `app/assets/stylesheets/scaffolds.scss` を削除します。これは Rails が標準で作成するファイルで私達にはもう必要の無いものです。
 
 ここまで来たら、[http://localhost:3000/ideas](http://localhost:3000/ideas)をリロードしてみましょう。何かが変わったことが確認出来ると思いますが、格好良くするためにはまだやることがありそうです。
 


### PR DESCRIPTION
[`app/assets/stylesheets/` に `scaffolds.css.scss` というファイルはなく、実際は `scaffold.scss` になっている。 · Issue #64 · railsgirls-jp/kyoto](https://github.com/railsgirls-jp/kyoto/issues/64) :lock: 

```
app/assets/stylesheets/ に scaffolds.css.scss というファイルはなく、実際は scaffold.scss になっている。
Rails のバージョンアップにつき変更になったものだが、Rails Girls のガイドが追従できていない。
「このファイルでいいんですか？」という質問がグループの全員から上がった。
```

上記 issue 対応しました :flashlight:

![image](https://cloud.githubusercontent.com/assets/4459676/11253805/f78e7090-8e80-11e5-9557-1fa424353694.png)

![image](https://cloud.githubusercontent.com/assets/4459676/11253836/23eeb71c-8e81-11e5-8b47-d49eb843c907.png)
