### PR TITLE
.navbarの更新だけだとnavbar-defaultの同じstyleの更新に負けるのを修正。

### DIFF
--- a/_posts/2014-01-05-design-using-html-and-css.markdown
+++ b/_posts/2014-01-05-design-using-html-and-css.markdown
@@ -9,17 +9,16 @@ permalink: design-html-css
 `app/assets/stylesheets/application.css` の最後に以下のコードを追加してください。：
 
 {% highlight css %}
-.navbar {
+nav.navbar {
   min-height: 38px;
   background-color: #f55e55;
+  background-image: none;
 }
 {% endhighlight %}
 
 では、ページを更新して変更を確認しましょう。
 それから、ヘッダーの色やフォントをいろいろ変えて、試してみましょう。
 [http://color.uisdc.com/](http://color.uisdc.com/) では、色のリファレンスを見ることができます。
-
-**コーチより：** `display` プロパティ、そして inline と block 要素について話してみましょう。
 
 次に、これらの行をコードの一番下に追加します。：
 


### PR DESCRIPTION
background-colorだけを上書きしてもbackground-imageの存在があるため、(おそらく)その後ろに色に背景色の設定が隠れるのを習性。
displayの設定がないため、コーチから説明をする行を削除。
