### PR TITLE
使用する Ruby のバージョンを 2.3.1 に変更、ガイド文の調整

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -98,7 +98,7 @@ rails server
 テキストエディタで `app/views/layouts/application.html.erb` (Windowsの場合  `app¥views¥layouts¥application.html.erb`) を開くと、次の行があります。
 
 {% highlight erb %}
-<%= stylesheet_link_tag "application", media: "all", "data-turbolinks-track" => true %>
+<%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
 {% endhighlight %}
 
 この1行前に次のタグを追記してください。

--- a/_posts/2012-04-30-commenting.markdown
+++ b/_posts/2012-04-30-commenting.markdown
@@ -66,10 +66,13 @@ belongs_to :idea
 app/views/ideas/show.html.erb を開いて、
 
 {% highlight erb %}
-<%= image_tag(@idea.picture_url, :width => 600) if @idea.picture.present? %>
+<p>
+  <strong>Picture:</strong>
+  <%= image_tag(@idea.picture_url, width: 600) if @idea.picture.present? %>
+</p>
 {% endhighlight %}
 
-この行のあとに、次のコードを追加します。
+このあとに、次のコードを追加します。
 
 {% highlight erb %}
 <h3>Comments</h3>
@@ -81,29 +84,32 @@ app/views/ideas/show.html.erb を開いて、
     <p><%= link_to 'Delete', comment_path(comment), method: :delete, data: { confirm: '削除してもよろしいですか？' } %></p>
   </div>
 <% end %>
-<%= render 'comments/form' %>
+<%= render 'comments/form', comment: @comment %>
 {% endhighlight %}
 
-`app/controllers/ideas_controller.rb` の show action には、
+`app/controllers/ideas_controller.rb` の show action の、
 
 {% highlight ruby %}
-@idea = Idea.find(params[:id])
+def show
+end
 {% endhighlight %}
 
-この次のあとに、こちらを追加します。
+この部分を以下のように書き換えます。
 
 {% highlight ruby %}
-@comments = @idea.comments.all
-@comment = @idea.comments.build
+def show
+  @comments = @idea.comments.all
+  @comment = @idea.comments.build
+end
 {% endhighlight %}
 
 `app/views/comments/_form.html.erb` を開いて、
 
 {% highlight erb %}
-  <div class="field">
-    <%= f.label :body %><br />
-    <%= f.text_area :body %>
-  </div>
+<div class="field">
+  <%= f.label :body %>
+  <%= f.text_area :body %>
+</div>
 {% endhighlight %}
 
 このあとに、次のタグを追加します。
@@ -116,7 +122,7 @@ app/views/ideas/show.html.erb を開いて、
 
 {% highlight erb %}
 <div class="field">
-  <%= f.label :idea_id %><br>
+  <%= f.label :idea_id %>
   <%= f.number_field :idea_id %>
 </div>
 {% endhighlight %}

--- a/_posts/2012-11-01-devise.markdown
+++ b/_posts/2012-11-01-devise.markdown
@@ -45,7 +45,7 @@ environments ファイルにデフォルトの url オプションを定義し�
 `config/environments/development.rb` を開いて次の行を追加しましょう。
 
 {% highlight ruby %}
-   config.action_mailer.default_url_options = { :host => 'localhost:3000' }
+config.action_mailer.default_url_options = { host: 'localhost:3000' }
 {% endhighlight %}
 
 `end` と書かれているところの前に追加してください。
@@ -112,20 +112,21 @@ Rails のサーバーが起動している事を確認したら、[http://localh
 
 {% highlight erb %}
 <p class="navbar-text pull-right">
-<% if user_signed_in? %>
-  Logged in as <strong><%= current_user.email %></strong>.
-  <%= link_to 'Edit profile', edit_user_registration_path, :class => 'navbar-link' %> |
-  <%= link_to "Logout", destroy_user_session_path, method: :delete, :class => 'navbar-link'  %>
-<% else %>
-  <%= link_to "Sign up", new_user_registration_path, :class => 'navbar-link'  %> |
-  <%= link_to "Login", new_user_session_path, :class => 'navbar-link'  %>
-<% end %>
+  <% if user_signed_in? %>
+    Logged in as <strong><%= current_user.email %></strong>.
+    <%= link_to 'Edit profile', edit_user_registration_path, class: 'navbar-link' %> |
+    <%= link_to "Logout", destroy_user_session_path, method: :delete, class: 'navbar-link'  %>
+  <% else %>
+    <%= link_to "Sign up", new_user_registration_path, class: 'navbar-link'  %> |
+    <%= link_to "Login", new_user_session_path, class: 'navbar-link'  %>
+  <% end %>
+</p>
 {% endhighlight %}
 
 これらを、次の行の上に追加します。
 
 {% highlight erb %}
-<ul class="nav">
+<ul class="nav navbar-nav">
   <li class="active"><a href="/ideas">Ideas</a></li>
 </ul>
 {% endhighlight %}

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -75,7 +75,7 @@ source ~/.bash_profile
 "rbenv install -l" コマンドでrbenvでインストール可能なRubyのバージョンを確認できます。
 
 {% highlight sh %}
-rbenv install 2.2.5
+rbenv install 2.3.1
 {% endhighlight %}
 
 ※もしも "OpenSSL::SSL::SSLError: ... : certificate verify failed" エラーが起きた場合は、以下の手順を試してみてください。
@@ -88,7 +88,7 @@ cp /usr/local/opt/curl-ca-bundle/share/ca-bundle.crt `ruby -ropenssl -e 'puts Op
 #### 3-A-5. デフォルトのRuby を設定:
 
 {% highlight sh %}
-rbenv global 2.2.5
+rbenv global 2.3.1
 {% endhighlight %}
 
 #### 3-A-6. Railsのインストール:
@@ -291,7 +291,7 @@ rails new railsgirls
 cd railsgirls
 rails server
 {% endhighlight %}
- 
+
 ### *2.* コードを編集するためのテキストエディタが必要になります。
 
 このワークショップでは Sublime Text エディタを推奨しています。

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -64,7 +64,7 @@ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/
 
 {% highlight sh %}
 brew update
-brew install rbenv rbenv-gem-rehash ruby-build
+brew install rbenv ruby-build
 echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
 echo 'export PATH="$HOME/.rbenv/shims:$PATH"' >> ~/.bash_profile
 source ~/.bash_profile


### PR DESCRIPTION
チュートリアルで使用する Ruby のバージョンを 2.3.1 に変更しました。
Rails 5.0.0 + Ruby 2.3.1 の組み合わせで、関連する項目（1, 2, 5, 7, 8, 9）を通してやってみて問題ないことを確認済みです。

併せて以下の対応も行っています。
- インストールガイドから Homebrew rbenv-gem-rehash の削除
  - インストール時にエラーが出る
    - `Error: No available formula with the name "rbenv-gem-rehash"`
  - 本家ガイドで削除済み
    - http://guides.railsgirls.com/install
- その他 Rails 5.0.0 で生成される内容や流れと合っていない箇所、わかりづらい箇所の調整
