### PR TITLE
Adopt Heroku page to rails5

### DIFF
--- a/_posts/2012-04-19-heroku.markdown
+++ b/_posts/2012-04-19-heroku.markdown
@@ -130,11 +130,24 @@ group :production do
 end
 {% endhighlight %}
 
+そして、ターミナル上で次のコマンドを実行してセットアップしてください。
+
+{% highlight sh %}
+bundle install --without production
+{% endhighlight %}
+
+{% highlight sh %}
+git add .
+git commit -a -m "Added pg gem and updated Gemfile.lock"
+{% endhighlight %}
+
 __Coachより__: RDBMS とそうでないものについて話してみましょう。Heroku 上の PostgreSQL の制限についても少し取り上げてみてください。
 
-#### rails\_12factor の導入
+#### rails\_12factor の導入(Rails4のみ)
 
-次に、Heroku で Rails 4 を動かすために必要な rails_12factor という gem を導入します。
+Rails4を利用している場合にはこの節の作業が必要になります。Rails5の場合は作業不要です。
+
+Heroku で Rails 4 を動かすために必要な rails_12factor という gem を導入します。
 
 この gem はアプリが Heroku 上で動作できるように、Rails の動作を変更します。例えば、ログは保存先が変更され、静的アセット(アプリの画像、スタイルシート、JavaScript ファイル) は Heroku 向けに微調整が加えられています。
 

--- a/_posts/2012-04-19-heroku.markdown
+++ b/_posts/2012-04-19-heroku.markdown
@@ -223,7 +223,7 @@ Total 134 (delta 26), reused 0 (delta 0)
 そして、ワークショップでローカルにやったように、データベースのマイグレートをする必要があります。 :
 
 {% highlight sh %}
-heroku run rake db:migrate
+heroku run rails db:migrate
 {% endhighlight %}
 
 そのコマンドが実行されたら、 url でアプリを見ることができます。このアプリの例では、 [http://evening-sky-7498.herokuapp.com/](http://evening-sky-7498.herokuapp.com) です。もしくは、ターミナルで次のコマンドを実行すれば、そのページを見に行くことができます。


### PR DESCRIPTION
Rails5 アプリでは rails_12factor gem は不要になったのでその記述を追加しました。

Heroku document of "Getting Started with Rails 5.x on Heroku."
https://devcenter.heroku.com/articles/getting-started-with-rails5#heroku-gems

"Previous versions of Rails required you toadd a gem to your project rails_12factor to enable static asset serving and logging on Heroku. If you are deploying a new application this gem is not needed."

また、 rake db:migrate を rails db:migrate に変更しています。

appページで作ったRails5アプリでHeroku動作確認OKでした。
