### PR TITLE
Replace ActiveRecord::Base to ApplicationRecord adopting Rails5 in the app page.

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -203,7 +203,7 @@ rails generate uploader Picture
 `app/models/idea.rb` を開いて、次の行
 
 {% highlight ruby %}
-class Idea < ActiveRecord::Base
+class Idea < ApplicationRecord
 {% endhighlight %}
 
 の直後に、


### PR DESCRIPTION
app page に ActiveRecord::Base が残ってたので ApplicationRecord に置き換えました。
issue #208 ActiveRecord::Base -> ApplicationRecord 
