### PR TITLE
Fix Git Cheetsheet Link.

### DIFF
--- a/_posts/2013-04-14-github.md
+++ b/_posts/2013-04-14-github.md
@@ -168,7 +168,7 @@ git push origin master
 ### Gitについてもっと学ぶ
 
  * [trygit.org](http://try.github.io/)をチェックアウトする
- * [GITチートシート](https://services.github.com/resources/)を使う
+ * [GITチートシート](https://services.github.com/kit/downloads/ja/github-git-cheat-sheet.pdf)を使う
  * [git-scm.org](http://git-scm.com/)でGitコマンドを眺めてみる
 
 


### PR DESCRIPTION
GITチートシートのリンクをクリックすると、各言語のGITチートシートを選択する英語のページが表示されます。
日本語のGITチートシートのPDFを表示するように変更しました。
