### PR TITLE
Ssl update 2016

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -236,7 +236,7 @@ gem -v
 もし `2.6.3` より古いバージョンだったら、以下の手順で更新する必要があります:
 
 {% highlight sh %}
-gem install gem install rubygems-update --source http://rubygems.org/
+gem install rubygems-update --source http://rubygems.org/
 update_rubygems --no-document
 gem uninstall rubygems-update -x
 {% endhighlight %}

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -233,7 +233,7 @@ server certificate B: certificate verify failed (https://rubygems.org/gems/i18n-
 gem -v
 {% endhighlight %}
 
-もし `2.6.3` より古いバージョンだったら、以下の手順で更新する必要があります:
+もし `2.6.5` より古いバージョンだったら、以下の手順で更新する必要があります:
 
 {% highlight sh %}
 gem install rubygems-update --source http://rubygems.org/
@@ -247,7 +247,7 @@ Rubygems のバージョンをチェックしましょう。
 gem -v
 {% endhighlight %}
 
-バージョンが `2.6.3` より大きいことを確かめてください。
+バージョンが `2.6.5` より大きいことを確かめてください。
 もし失敗していたらやり直してください。
 
 続いて、bundler gem も更新が必要となる場合があります。まず `bundle` のバージョンをチェックしましょう。

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -233,12 +233,10 @@ server certificate B: certificate verify failed (https://rubygems.org/gems/i18n-
 gem -v
 {% endhighlight %}
 
-もし `2.2.3` より古いバージョンだったら、以下の手順で更新する必要があります:
-
-[ruby-gems-update gem](https://github.com/rubygems/rubygems/releases/download/v2.2.3/rubygems-update-2.2.3.gem) をダウンロードし、それを `c:\rubygems-update-2.2.3.gem` として保存して実行してください:
+もし `2.6.3` より古いバージョンだったら、以下の手順で更新する必要があります:
 
 {% highlight sh %}
-gem install --local c:\\rubygems-update-2.2.3.gem
+gem install gem install rubygems-update --source http://rubygems.org/
 update_rubygems --no-document
 gem uninstall rubygems-update -x
 {% endhighlight %}
@@ -249,7 +247,28 @@ Rubygems のバージョンをチェックしましょう。
 gem -v
 {% endhighlight %}
 
-バージョンが `2.2.3` より大きいことを確かめてください。
+バージョンが `2.6.3` より大きいことを確かめてください。
+もし失敗していたらやり直してください。
+
+続いて、bundler gem も更新が必要となる場合があります。まず `bundle` のバージョンをチェックしましょう。
+
+{% highlight sh %}
+bundle -v
+{% endhighlight %}
+
+もし `1.12.0` より古いバージョンだったら、以下の手順で更新する必要があります:
+
+{% highlight sh %}
+gem update bundler --no-document
+{% endhighlight %}
+
+`bundle` のバージョンをチェックしましょう。
+
+{% highlight sh %}
+bundle -v
+{% endhighlight %}
+
+バージョンが `1.12.0` より大きいことを確かめてください。
 もし失敗していたらやり直してください。
 
 

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -256,7 +256,7 @@ gem -v
 bundle -v
 {% endhighlight %}
 
-もし `1.12.0` より古いバージョンだったら、以下の手順で更新する必要があります:
+もし `1.13.0` より古いバージョンだったら、以下の手順で更新する必要があります:
 
 {% highlight sh %}
 gem update bundler --no-document
@@ -268,7 +268,7 @@ gem update bundler --no-document
 bundle -v
 {% endhighlight %}
 
-バージョンが `1.12.0` より大きいことを確かめてください。
+バージョンが `1.13.0` より大きいことを確かめてください。
 もし失敗していたらやり直してください。
 
 


### PR DESCRIPTION
[Rails Girls Nagoya 3rd](http://railsgirls.com/nagoya) インストール・ ディ（2016/10/28）で起きた問題と対処法の反映です。

起きた問題：
- [rubygems.org](https://rubygems.org/) のSSL証明書が更新されたため、Windows の RailsInstaller でインストールした Rubygems や bundler が古くてエラーが出た。
  - Rubygems の方は、インストールガイドに載っていたのと同じ `Gem::RemoteFetcher` エラー。
  - bundler の方は「https:// ではなく http:// で再度試してみてください」という旨のエラー。

対処法：
- Rubygems を http:// 経由で最新に更新。
  - 元々インストールガイドに載っていた方法では、2016/09/28 以降に更新された証明書に対応できない。
- その後 bundler gem を更新。

参考：
- [補足：証明書について - Windows環境でgemがSSLエラー 2016 - Qiita](http://qiita.com/betrue12/items/059c2424f27fd31969f9#%E8%A3%9C%E8%B6%B3%E8%A8%BC%E6%98%8E%E6%9B%B8%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)

よろしくお願いします。
