### PR TITLE
Fix git cheatsheet link.

### DIFF
--- a/_posts/2013-04-14-github.md
+++ b/_posts/2013-04-14-github.md
@@ -168,7 +168,7 @@ git push origin master
 ### Gitについてもっと学ぶ
 
  * [trygit.org](http://try.github.io/)をチェックアウトする
- * [GITチートシート](https://services.github.com/kit/downloads/ja/github-git-cheat-sheet.pdf)を使う
+ * [GITチートシート](https://services.github.com/on-demand/downloads/ja/github-git-cheat-sheet.pdf)を使う
  * [git-scm.org](http://git-scm.com/)でGitコマンドを眺めてみる
 
 


### PR DESCRIPTION
This time URL was taken from https://services.github.com/resources/.