### PR TITLE
Install bundler before installing rails.

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -91,7 +91,13 @@ cp /usr/local/opt/curl-ca-bundle/share/ca-bundle.crt `ruby -ropenssl -e 'puts Op
 rbenv global 2.3.3
 {% endhighlight %}
 
-#### 3-A-6. Railsのインストール:
+#### 3-A-6. Bundlerのインストール:
+
+{% highlight sh %}
+gem install bundler --no-document
+{% endhighlight %}
+
+#### 3-A-7. Railsのインストール:
 
 {% highlight sh %}
 gem install rails --no-document


### PR DESCRIPTION
Students can't execute bundle install on Mac.
Install procedure is `rbenv install <ver>` -> `gem install rails` -> `rails new railsgirls`.
Maybe bundle install will be fail on `rails new`.

RailsInstaller installs bundler so students can use bundler on Windows.
[Install script](https://github.com/railsgirls/installation-scripts/blob/5707a934c402dfc9f11196f5a383a78f3b4fd7bc/rails-install-ubuntu.sh#L33) installs bundler so students can use bundler on Linux.