### PR TITLE
Conform Atom download link same as Mac.

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -168,10 +168,7 @@ gem update rails --no-document
 
 このワークショップでは Atom エディタを推奨しています。
 
-* [Atom エディタをダウンロードしてインストールする](https://github.com/atom/atom/releases/latest)
-  * 上記リンクから zip ファイルをダウンロードして展開します
-  * Atom フォルダを Program Files フォルダへコピーします
-  * コピーしたフォルダから atom を起動します
+* [Atom エディタをダウンロードしてインストールする](https://atom.io/)
 
 Windows Vista およびそれ以前のバージョンでは Atom エディタは非対応ですが、[Sublime Text エディタ](http://www.sublimetext.com/2) を利用可能です。(※Windows で Sublime Text を使う場合、日本語入力欄が入力箇所に出ない問題があります。気になる場合は以下の手順で日本語入力パッチ(修正プログラム)をインストールしてください。[Sublime Text 日本語入力パッチ](https://github.com/chikatoike/IMESupport/archive/master.zip)をダウンロードします。Sublime Text アプリメニューの Preferences から Browse Packeges を選び、フォルダを表示させます。 ダウンロードしたzipを解凍してできたフォルダ(IMESupport-master)をここへコピーします。Sublime Text が起動している場合は再起動します。)
 


### PR DESCRIPTION
It was difficult to know download link from https://github.com/atom/atom/releases/latest in below reasons.
* Filename was not written.
* Finding atom-windows.zip? needs to scroll.
* Teachers were wondered about difference Mac procedure.