### PR TITLE
Drop rails4

### DIFF
--- a/_posts/2012-04-19-heroku.markdown
+++ b/_posts/2012-04-19-heroku.markdown
@@ -135,44 +135,6 @@ git commit -a -m "Added pg gem and updated Gemfile.lock"
 
 __Coachより__: RDBMS とそうでないものについて話してみましょう。Heroku 上の PostgreSQL の制限についても少し取り上げてみてください。
 
-#### rails\_12factor の導入(Rails4のみ)
-
-Rails4を利用している場合にはこの節の作業が必要になります。Rails5の場合は作業不要です。
-
-Heroku で Rails 4 を動かすために必要な rails_12factor という gem を導入します。
-
-この gem はアプリが Heroku 上で動作できるように、Rails の動作を変更します。例えば、ログは保存先が変更され、静的アセット(アプリの画像、スタイルシート、JavaScript ファイル) は Heroku 向けに微調整が加えられています。
-
-Gemfile を次のように変更しましょう。:
-
-{% highlight ruby %}
-group :production do
-  gem 'pg'
-end
-{% endhighlight %}
-
-↓
-
-{% highlight ruby %}
-group :production do
-  gem 'pg'
-  gem 'rails_12factor'
-end
-{% endhighlight %}
-
-そして、ターミナル上で次のコマンドを実行してセットアップしてください。
-
-{% highlight sh %}
-bundle install --without production
-{% endhighlight %}
-
-{% highlight sh %}
-git add .
-git commit -a -m "Added rails_12factor gem and updated Gemfile.lock"
-{% endhighlight %}
-
-__Coachより__: Heroku におけるログの仕組みについて調べてみましょう。
-
 ### アプリのデプロイ
 
 #### アプリのcreate

--- a/_posts/2013-04-08-how-to-continue-with-programming.markdown
+++ b/_posts/2013-04-08-how-to-continue-with-programming.markdown
@@ -43,7 +43,7 @@ and was published on
 
 ### 書籍（日本語）
 
-* [Railsチュートリアル](http://railstutorial.jp/) - 先ほど紹介した書籍の日本語訳です。原著と同様に、HTML ならば無料、電子書籍ならば有料となっています。Rails3.2とRails 4.0に対応。
+* [Railsチュートリアル](http://railstutorial.jp/) - 先ほど紹介した書籍の日本語訳です。原著と同様に、HTML ならば無料、電子書籍ならば有料となっています。Rails3.2、4.0、4.2、5.0に対応。
 
 * [HerokuではじめるRailsプログラミング入門](http://www.amazon.co.jp/dp/4797371838) - Rails初心者向けの書籍です。簡単なWebアプリケーションをつくり、Herokuにデプロイする手順を丁寧に解説しています。
 
@@ -53,7 +53,7 @@ and was published on
 
 * [たのしいRuby 第4版](http://www.amazon.co.jp/dp/4797372273) - 定番の Ruby 入門書です。Rails の礎となっているRubyを勉強してみたい方へお勧めです。
 
-* [Railsガイド](http://railsguides.jp/) - Railsを体系的に学ぶための大型リファレンスガイドです。Web版は全て無料。Rails 4.2に対応しています。
+* [Railsガイド](http://railsguides.jp/) - Railsを体系的に学ぶための大型リファレンスガイドです。Web版は全て無料。Rails 5.0に対応しています。
 
 
 ### スクリーンキャスト


### PR DESCRIPTION
Drop Rails 4 because almost contents supports only Rails 5(ex. rails command).

If Rails 4 contents left, students will be misunderstood this guides supports Rails 4 and 5.