### PR TITLE
Add another windows installation procedure.

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -147,6 +147,7 @@ Mac OS X 10.7 およびそれ以前のバージョンでは、 Atom エディタ
 
 [RailsInstaller](https://s3.amazonaws.com/railsinstaller/Windows/railsinstaller-3.2.1.exe) をダウンロードして、実行します。
 インストールのオプションは全てデフォルトを選択します。
+(※もしRailsInstallerでうまくいかない場合は[こちら](/win_another_install)の方法を試してみてください。インストール後は2.、3.、5.と進んでください)
 
 `Command Prompt with Ruby on Rails`から以下のコマンドを実行します:
 

--- a/_posts/2017-01-28-windows-another-install.markdown
+++ b/_posts/2017-01-28-windows-another-install.markdown
@@ -1,0 +1,39 @@
+---
+layout: default
+title: Rails Girls インストール・レシピ(Windows)
+permalink: win_another_install
+---
+
+# Rails Girls インストール・レシピ(Windows)
+<span class="muted">クッキングタイム: 5分 (作業時間) / 15-30分 (待ち時間)</span>
+
+## インストール
+
+1. [ここ](https://github.com/sho-h/ruby_env/archive/master.zip)からRuby本体とRails一式をダウンロードして `C:\ruby_env` となるように展開します
+2. `C:\ruby_env\cmd.bat` へのショートカットをデスクトップに作成します
+3. `C:\ruby_env\src` へのショートカットをデスクトップに作成します
+4. デスクトップの `cmd.bat` を実行してから以下のコマンドを実行します
+
+{% highlight sh %}
+rails -v
+{% endhighlight %}
+
+もしもRailsのバージョンが5よりも小さい場合は 以下のコマンドを実行することでバージョンアップできます。
+
+{% highlight sh %}
+gem update rails --no-document
+{% endhighlight %}
+
+これで完了です。今後コマンドを実行する手順を実施する時は同じようにデスクトップの`cmd.bat`から実行してください。プログラムは同じように`src`以下に作成すると移動しやすいです。
+
+では、元のレシピに戻って作業を続けてください。
+
+## アンインストール
+
+1. `C:\ruby_env\src`以下で作成したプログラムをバックアップします(必要な場合のみ)
+2. `C:\ruby_env\`を削除します
+3. デスクトップに作成したショートカットを削除します
+
+これで完了です。
+
+*コーチの方へ*: 本手順にてインストールを行った場合はレジストリ等は書き換えられる事はありません。インストールしたgemなども`C:\ruby_env\`以下に展開されているため、元々の環境は汚れていません。もし参加者の方が削除して大丈夫かなどが気になるようでしたら少し説明してあげてください。


### PR DESCRIPTION
Add another windows installation procedure because RailsInstaller is not maintained(see below links).

* https://medium.com/@emachnic/shutting-down-work-on-railsinstaller-4087dc1bc6b0#.cfnn1ga9m
* https://twitter.com/emachnic/status/814925600972476416

This is trying to make another windows installation procedure. Students download archive including Ruby, Ruby on Rails, nodejs(see https://github.com/railsgirls-jp/matsue/issues/154).