### PR TITLE
Only remove link color on immediate child.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -180,8 +180,8 @@ footer a {
   -moz-transition: 0.10s background-color ease-in;
 }
 
-.home a,
-.home a:hover {
+.home li > a,
+.home li > a:hover {
   color: inherit;
   text-decoration: none;
   cursor: pointer;


### PR DESCRIPTION
index.htmlのリンクの色の表示が http://guides.railsgirls.com/ と違う状態です。
たとえばindex.htmlの④のリンクの色が黒色ですが、 http://guides.railsgirls.com/  では赤色で表示されています。

http://guides.railsgirls.com/ と同じリンクの色になるように https://github.com/railsgirls/railsgirls.github.io にて修正されたコミット `6bccd9536f8dad5a8be78b1b067fb8a0c9cefc0d` を持ってきました。


