### PR TITLE
Fix can't ignore public/uploads on Windows because Windows echo command outputs double quote.

### DIFF
--- a/_posts/2012-04-19-heroku.markdown
+++ b/_posts/2012-04-19-heroku.markdown
@@ -76,7 +76,7 @@ __Coachより__: Heroku か、従来のサーバーか、デプロイの利点�
 
 {% highlight sh %}
 git init
-echo "public/uploads" >> .gitignore
+echo public/uploads >> .gitignore
 git add .
 git commit -m "initial commit"
 {% endhighlight %}


### PR DESCRIPTION
Windows echo command outputs `"public/uploads"`. This is not expected and not works.
Mac sh/bash/zsh echo command outputs `public/uploads`. This is expected and works fine.

see: https://github.com/railsgirls-jp/matsue/issues/176