### PR TITLE
Remove Google Analytics because tracking ID is the same with .com. (closes #270)

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,18 +11,5 @@
         <a href="https://www.facebook.com/railsgirls">Facebook</a>
       </p>
     </footer>
-    <script type="text/javascript">
-      //<![CDATA[
-        var _gaq = _gaq || [];
-        _gaq.push(["_setAccount", "UA-19631067-3"]);
-        _gaq.push(["_trackPageview"]);
-
-        (function() {
-          var ga = document.createElement("script"); ga.type = "text/javascript"; ga.async = true;
-          ga.src = ("https:" == document.location.protocol ? "https://ssl" : "http://www") + ".google-analytics.com/ga.js";
-          var s = document.getElementsByTagName("script")[0]; s.parentNode.insertBefore(ga, s);
-        })();
-      //]]>
-    </script>
   </body>
 </html>


### PR DESCRIPTION
see #270