### PR TITLE
WinでRailsInstaller3.3.0 の問題を修正する記述を追加

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -144,8 +144,31 @@ Mac OS X 10.7 およびそれ以前のバージョンでは、 Atom エディタ
 
 ### *1.* Install Rails
 
-[RailsInstaller](https://s3.amazonaws.com/railsinstaller/Windows/railsinstaller-3.2.1.exe) をダウンロードして、実行します。
-インストールのオプションは全てデフォルトを選択します。
+[RailsInstaller](https://s3.amazonaws.com/railsinstaller/Windows/railsinstaller-3.3.0.exe) をダウンロードして、実行します。インストールのオプションは全てデフォルトを選択します。
+
+インストール後にRailsInstaller3.3.0の問題を修正します。 以下は `C:¥RailsInstaller` フォルダへインストールした前提で書いています。
+
+`C:¥RailsInstaller¥Ruby2.3.0¥bin¥bundle.bat` ファィルをエディタで開きます。 `C:\Users\emachnic\GitRepos\railsinstaller-windows\stage\Ruby2.3.0\bin\` と書かれた箇所を全て削除します。修正後のファイルは以下のようになります。
+
+{% highlight sh %}
+@ECHO OFF
+IF NOT "%~f0" == "~f0" GOTO :WinNT
+@"ruby.exe" "bundle" %1 %2 %3 %4 %5 %6 %7 %8 %9
+GOTO :EOF
+:WinNT
+@"ruby.exe" "%~dpn0" %*
+{% endhighlight %}
+
+次に、 `C:¥RailsInstaller¥Ruby2.3.0¥bin¥rails.bat` ファイルを開き、同様に修正します。修正後のファイルは以下のようになります。
+
+{% highlight sh %}
+@ECHO OFF
+IF NOT "%~f0" == "~f0" GOTO :WinNT
+@"ruby.exe" "rails" %1 %2 %3 %4 %5 %6 %7 %8 %9
+GOTO :EOF
+:WinNT
+@"ruby.exe" "%~dpn0" %*
+{% endhighlight %}
 
 `Command Prompt with Ruby on Rails`から以下のコマンドを実行します:
 


### PR DESCRIPTION
installページのWinのRailsInstallerに関する問題を解決する記述を追加します。

- （ついでに）RailsInstallerを英語ガイドにあわせて3.3.0へ
- RailsInstaller3.3.0用のバグ修正方法を追記

英語版ガイドのこのPRの日本語版です。 https://github.com/railsgirls/railsgirls.github.io/pull/338