### PR TITLE
Remove header color.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -53,7 +53,6 @@ p {
 }
 
 h3, h4, h5, a {
-  color:#e0330c;
   line-height:1.1;
 }
 


### PR DESCRIPTION
h3, h4, h5の見出しの色とaのリンクの色が同じなので、見出しにあるリンクが分からない状態になっていいます。

たとえば http://guides.railsgirls.com/install の「3a2. Install Homebrew:」や「3a3. Install rbenv:」のような見出しにあるリンクです。
http://railsgirls.jp/install は同じ色になっています。

削除したコードは `e9c68221e9423737fc37324a3e54707fa33b0b35` で追加されていました。
ログによると railsgirls.jp の独自の表示のために追加されていたので、メニューにあるEvents, Blog, Sponsors, CoC, Aboutの各表示を確認して影響がなさそうに見えたので削除しました。