### PR TITLE
Fix jump link to virtual machine section in page.

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -356,7 +356,7 @@ rails server
 
 <hr />
 
-## 仮想マシン
+## <a id="virtual-machine">仮想マシン</a>
 
 自分のコンピュータにインストールする代わりに仮想マシン上で開発環境をセットアップすることもできます。
 詳しいことは [ここ]({% post_url 2014-03-24-alternative-dev-environment %}) を参照してください。


### PR DESCRIPTION
Rails Girls インストール・レシピのページ内のリンク（Alternative Installment for all OS）が、リンクをクリックしても仮想マシンの説明に移動しない状態でしたので修正しました。

http://railsgirls.jp/install