### PR TITLE
Remove rails installer from Mac install instruction

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -45,23 +45,23 @@ Appleメニューをクリックして *About This Mac* (図 1) を選びます�
 
 図 2
 
-### *3-A.* rbenv を使って Ruby と Ruby on Rails をインストール(OS X 10.9 以上の場合):
+### *3.* rbenv を使って Ruby と Ruby on Rails をインストール(OS X 10.9 以上の場合):
 
 OS X 10.9 以上の場合は、Homebrew と rbenv を使って環境をつくります。
 
-#### 3-A-1. Command line tools をターミナルからインストール:
+#### 3-1. Command line tools をターミナルからインストール:
 
 {% highlight sh %}
 xcode-select --install
 {% endhighlight %}
 
-#### 3-A-2. [Homebrew](http://brew.sh/)をインストール:
+#### 3-2. [Homebrew](http://brew.sh/)をインストール:
 
 {% highlight sh %}
 ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 {% endhighlight %}
 
-#### 3-A-3. [rbenv](https://github.com/rbenv/rbenv)をインストール:
+#### 3-3. [rbenv](https://github.com/rbenv/rbenv)をインストール:
 
 {% highlight sh %}
 brew update
@@ -70,7 +70,7 @@ echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
 source ~/.bash_profile
 {% endhighlight %}
 
-#### 3-A-4. rbenvを使ってRubyをインストール:
+#### 3-4. rbenvを使ってRubyをインストール:
 
 "rbenv install -l" コマンドでrbenvでインストール可能なRubyのバージョンを確認できます。
 
@@ -85,38 +85,22 @@ brew install curl-ca-bundle
 cp /usr/local/opt/curl-ca-bundle/share/ca-bundle.crt `ruby -ropenssl -e 'puts OpenSSL::X509::DEFAULT_CERT_FILE'`
 {% endhighlight %}
 
-#### 3-A-5. デフォルトのRuby を設定:
+#### 3-5. デフォルトのRuby を設定:
 
 {% highlight sh %}
 rbenv global 2.5.0
 {% endhighlight %}
 
-#### 3-A-6. Bundlerのインストール:
+#### 3-6. Bundlerのインストール:
 
 {% highlight sh %}
 gem install bundler --no-document
 {% endhighlight %}
 
-#### 3-A-7. Railsのインストール:
+#### 3-7. Railsのインストール:
 
 {% highlight sh %}
 gem install rails --no-document
-{% endhighlight %}
-
-#### *3-B.* 使用している OS Xのバージョン用 RailsInstaller ダウンロードします。(OS X10.6, 10.7, 10.8の場合)
-
-* [10.7, 10.8 用 RailsInstaller](http://railsinstaller.s3.amazonaws.com/RailsInstaller-1.0.4-osx-10.7.app.tgz) <span class="muted">(325MB)</span>
-* [10.6 用 RailsInstaller](http://railsinstaller.s3.amazonaws.com/RailsInstaller-1.0.4-osx-10.6.app.tgz) <span class="muted">(224MB)</span>
-
-ダウンロードしたファイルをダブルクリックするとカレントディレクトリに解凍されます。
-この解凍された'RailsInstaller-1.0.4-osx-10.7.app' あるいは 'RailsInstaller-1.0.4-osx-10.6.app' を
-ダブルクリックしてインストラクションに従ってインストールします。インストーラが 'Rails Installer OS X'と冒頭に書いて
-あるREADMEファイルを開きますが、このインストラクションは **無視** してください。
-
-もしもRailsのバージョンが最新ではない場合は、以下のコマンドをターミナルから実行することでバージョンアップできます。
-
-{% highlight sh %}
-gem update rails --no-document
 {% endhighlight %}
 
 ### *4.* コードを編集するのに必要なテキストエディタをインストールする。


### PR DESCRIPTION
It's too outdated.