### PR TITLE
/events以下の大阪開催の画像URLを修正

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -60,7 +60,7 @@ title: "Rails Girls Events"
     <h3>Okayama<small>2017/02/25-26</small></h3>
   </a>
 
-  <a href="http://railsgirls.com/osaka.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-osaka4th-event.png) 0px 0px / 100% no-repeat;">
+  <a href="http://railsgirls.com/osaka.html" class="span4 event" style="background:url(http://railsgirls.com/images/osaka/rg-osaka4th-event.png) 0px 0px / 100% no-repeat;">
     <h3>Osaka<small>2017/02/17-18</small></h3>
   </a>
 
@@ -88,7 +88,7 @@ title: "Rails Girls Events"
     <h3>Tokyo<small>2016/07/22-23</small></h3>
   </a>
 
-  <a href="http://railsgirls.com/osaka-3rd.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-osaka-3rd.png) 0px 0px / 100% no-repeat;">
+  <a href="http://railsgirls.com/osaka-3rd.html" class="span4 event" style="background:url(http://railsgirls.com/images/osaka/rg-osaka-3rd.png) 0px 0px / 100% no-repeat;">
     <h3>Osaka<small>2016/06/18-19</small></h3>
   </a>
 
@@ -120,7 +120,7 @@ title: "Rails Girls Events"
     <h3>Fukuoka<small>2015/07/24-25</small></h3>
   </a>
 
-  <a href="http://railsgirls.com//osaka-2nd.html" class="span4 event" style="background: url(http://railsgirls.com/images/rg-osaka-2nd.jpg) 0px -100px / 95% no-repeat;">
+  <a href="http://railsgirls.com//osaka-2nd.html" class="span4 event" style="background: url(http://railsgirls.com/images/osaka/rg-osaka-2nd.jpg) 0px -100px / 95% no-repeat;">
     <h3>Osaka<small>2015/06/19-20</small></h3>
   </a>
 
@@ -144,7 +144,7 @@ title: "Rails Girls Events"
     <h3>Tokyo <small>2014/09/21</small></h3>
   </a>
 
-  <a href="http://railsgirls.com/osaka-1st.html" class="span4 event" style="background: url(http://railsgirls.com/images/rg-osaka-1st.jpg) -35px -110px no-repeat;">
+  <a href="http://railsgirls.com/osaka-1st.html" class="span4 event" style="background: url(http://railsgirls.com/images/osaka/rg-osaka-1st.jpg) -35px -110px no-repeat;">
     <h3>Osaka<small>2014/06/06-07</small></h3>
   </a>
 


### PR DESCRIPTION
本家のimagesの構成が変更になっており404になっていたのを修正しました。