### PR TITLE
package.jsonを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "railsgirls.jp",
+  "version": "1.0.0",
+  "comment": "このファイルはダミーです。GitHubに脆弱性を検知してもらうためだけに置いています。利用するJavaScriptのバージョン更新にあわせて、本ファイルのバージョンを更新して使用する事を想定しています。",
+  "dependencies": {
+    "prefixfree": "1.0.6",
+    "jquery": "1.7.2",
+    "js-cookie": "1.3.1",
+    "bootstrap": "2.3.2"
+  }
+}


### PR DESCRIPTION
js以下はどのファイルを更新すべきかがわかりにくいためダミーのpackage.jsonを用意してみました。脆弱性の検知のためにGemfile.lockだけ置いているようなものだとでも思っていただければと思います。
利用するJavaScriptのバージョン更新にあわせて、このファイル中のバージョンを更新して使用する事を想定していますが、普通にpackage.jsonとして利用されてもいいのではないかとも思います。その時はcommentの行を削除してREADMEに手順を書くといった形を考えています。現時点では直接ファイルを置き換える以外のJSの更新方法はよくわかっていません。