### PR TITLE
WIP: RubyGemsのバージョンを更新

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -244,12 +244,12 @@ server certificate B: certificate verify failed (https://rubygems.org/gems/i18n-
 gem -v
 {% endhighlight %}
 
-もし `2.6.5` より古いバージョンだったら、以下の手順で更新する必要があります:
+もし `2.7.6` より古いバージョンだったら、以下の手順で更新する必要があります:
 
-[ruby-gems-update gem](https://rubygems.org/downloads/rubygems-update-2.6.7.gem) をダウンロードし、それを `c:\rubygems-update-2.6.7.gem` として保存して実行してください:
+[ruby-gems-update gem](https://rubygems.org/downloads/rubygems-update-2.7.6.gem) をダウンロードし、それを `c:\rubygems-update-2.7.6.gem` として保存して実行してください:
 
 {% highlight sh %}
-gem install --local c:\\rubygems-update-2.6.7.gem
+gem install --local c:\\rubygems-update-2.7.6.gem
 update_rubygems --no-document
 gem uninstall rubygems-update -x
 {% endhighlight %}
@@ -260,7 +260,7 @@ Rubygems のバージョンをチェックしましょう。
 gem -v
 {% endhighlight %}
 
-バージョンが `2.6.5` より大きいことを確かめてください。
+バージョンが `2.7.6` より大きいことを確かめてください。
 もし失敗していたらやり直してください。
 
 続いて、bundler gem も更新が必要となる場合があります。まず `bundle` のバージョンをチェックしましょう。


### PR DESCRIPTION
RubyGemsの更新の手順中のバージョンを新しいものに修正しました。元々は証明書関連のファイルを更新するのが目的だったかと思いますが、更新するなら[この問題](https://www.ruby-lang.org/ja/news/2018/02/17/multiple-vulnerabilities-in-rubygems/)を気にしなくていいバージョンまで上げる手順にしておくのがよいと思ったためです。

rubygems-update-2.7.6.gemが保存できる事しか確認していませんので、マージする場合は誰かが動作確認してからがいいかと思います。