### PR TITLE
uninstall rvm to migrate to rbenv on cloud9

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -507,7 +507,13 @@ bundle exec rails s -b 0.0.0.0
 * Workspace name には好きな名前をつけましょう。'Team' はRailsGirls Japanを選び 'Choose a template' では下段の右から2番目の 'blank' を選択して 'Create workspace' ボタンをクリックします。
 * 利用可能になるまで少し待ってください。
 
-### *4.* rbenv を使って Ruby の version を最新にする
+### *4.* 標準でインストールされている RVM をアンインストールする
+
+{% highlight sh %}
+sudo rvm implode
+{% endhighlight %}
+
+### *5.* rbenv を使って Ruby の version を最新にする
 
 "ruby -v" コマンドでRubyのバージョンを確認できます。
 最新の2.5.1では無い場合は2.5.1をインストールしましょう。
@@ -522,19 +528,19 @@ rbenv install 2.5.1
 rbenv global 2.5.1
 {% endhighlight %}
 
-### *5.* Bundlerのインストール
+### *6.* Bundlerのインストール
 
 {% highlight sh %}
 gem install bundler --no-document
 {% endhighlight %}
 
-### *6.* Railsのインストール
+### *7.* Railsのインストール
 
 {% highlight sh %}
 gem install rails --no-document
 {% endhighlight %}
 
-#### *7.* 開発する
+#### *8.* 開発する
 
 * 左側はフォルダとファイルを表示、選択できます。
 * 中央部はエディタです。ここでファイルを編集します。


### PR DESCRIPTION
rvmをアンインストールせずにrbenvをインストールすると以下のようなエラーが発生することを確認しました。

```
$ gem install bundler --no-document
Ignoring executable-hooks-1.3.2 because its extensions are not built. Try: gem pristine executable-hooks --version 1.3.2
Ignoring gem-wrappers-1.2.7 because its extensions are not built. Try: gem pristine gem-wrappers --version 1.2.7
Error loading RubyGems plugin "/usr/local/rvm/gems/ruby-2.4.0@global/gems/executable-hooks-1.3.2/lib/rubygems_plugin.rb": cannot load such file -- executable-hooks/wrapper (LoadError)
Error loading RubyGems plugin "/usr/local/rvm/gems/ruby-2.4.0@global/gems/gem-wrappers-1.2.7/lib/rubygems_plugin.rb": cannot load such file -- gem-wrappers (LoadError)
Fetching: bundler-1.16.1.gem (100%)
Successfully installed bundler-1.16.1
1 gem installed
```

これの対応方法となります。

![screen shot 2018-05-12 at 15 43 53](https://user-images.githubusercontent.com/5103178/39954505-ba12debe-55fb-11e8-8855-462b00ba9d43.png)