### PR TITLE
back to tumblr link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -30,7 +30,7 @@
         <span>日本語版</span>
         <a href="/">Home</a>
         <a href="/events/">Events</a>
-        <a href="/blog">Blog</a>
+        <a href="http://blog.railsgirls.jp">Blog</a>
         <a href="/sponsors/">Sponsors</a>
         <a href="/code-of-conduct">CoC</a>
         <a href="/about">About</a>


### PR DESCRIPTION
ブログ移行でつかったpluginがサポートされていなくて画面表示に失敗したので、
いったんリンク先をTumblrに戻します... 