### PR TITLE
スマホで表示したときのブログのレイアウト崩れを修正

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -17,14 +17,14 @@
     </div>
 
     <div class="row page__link">
-      <div class="span4">
+      <div class="page__link--next">
         {% if page.next %}
           <p class="pager__item--next">
             <a href="{{ page.next.url | relative_url }}">&lt; {{ page.next.title }}</a>
           </p>
         {% endif %}
       </div>
-      <div class="span4 text-right">
+      <div class="page__link--prev">
         {% if page.previous %}
           <p class="pager__item--prev">
             <a href="{{ page.previous.url | relative_url }}">{{ page.previous.title }} &gt;</a>

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,11 +4,11 @@ title: Blog
 ---
 
 <!-- 記事一覧 -->
-<div class="row row-eq-height" style="padding-top: 20px;">
+<div class="row row-eq-height">
 
   {% for post in paginator.posts %}
 
-  <article class="span4 entry" style="position: relative;">
+  <article class="span3 entry" style="position: relative;">
     <div class="entry_inner">
       <div class="entry-header">
         <img src="{{ post.image }}" alt="" title="" style="width: 100%; height: 15rem; object-fit: cover;">

--- a/css/style.css
+++ b/css/style.css
@@ -316,20 +316,19 @@ i.icon-small-browser {
 .row-eq-height {
   display: flex;
   flex-wrap: wrap;
+  float: left;
+  margin-top: 10px;
+  margin-bottom: 20px;
 }
 
 .entry {
   position: relative;
   overflow: hidden;
-  width: calc(32% - 2em);
   margin: 1em 1em 0;
   box-sizing: border-box;
   border-radius: .2em;
   background: rgba(247, 244, 237, .8);
   transition: ease .14s;
-  /*box-shadow:*/
-      /*-3px 4px rgba(231, 76, 60, .2),*/
-      /*3px -4px rgba(233, 212, 96, .5);*/
   font-family: "YuGothic","Yu Gothic","Meiryo","ヒラギノ角ゴ","sans-serif";
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -401,6 +401,10 @@ i.icon-small-browser {
   width: 30%;
 }
 
+.page__body {
+  word-break: break-all;
+}
+
 .page__link {
   margin-top: 3em;
   background: rgba(247, 244, 237, .8);
@@ -409,6 +413,15 @@ i.icon-small-browser {
 
 .page__link div {
   width: calc(50% - 2em);
+}
+
+.page__link .page__link--next {
+  float: left;
+}
+
+.page__link .page__link--prev {
+  float: right;
+  text-align: right;
 }
 
 .page__link div p {


### PR DESCRIPTION
小さい画面で表示したときにレイアウトが崩れていたので修正しました。
- ブログ記事一覧画面
  - 小さい画面でも3列表示になってしまっていたのを、1列表示になるようにしました。
- 記事画面
  - 前の記事、次の記事へのリンクの表示が崩れていたので修正しました。