### PR TITLE
jQueryを段階的に更新その1

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,6 +8,13 @@
   <![endif]-->
   <script src="/js/prefixfree.min.js"></script>
   <script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js" type="text/javascript"></script>
+  <script>
+    jQuery.ajaxPrefilter( function( s ) {
+      if ( s.crossDomain ) {
+          s.contents.script = false;
+      }
+    } );
+  </script>
   <script src="/js/jquery.cookie.js"></script>
   <script src="/js/guides.js"></script>
   <script src="/js/bootstrap-dropdown.js"></script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,7 @@
   <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
   <script src="/js/prefixfree.min.js"></script>
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js" type="text/javascript"></script>
   <script src="/js/jquery.cookie.js"></script>
   <script src="/js/guides.js"></script>
   <script src="/js/bootstrap-dropdown.js"></script>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "comment": "このファイルはダミーです。GitHubに脆弱性を検知してもらうためだけに置いています。利用するJavaScriptのバージョン更新にあわせて、本ファイルのバージョンを更新して使用する事を想定しています。",
   "dependencies": {
     "prefixfree": "1.0.6",
-    "jquery": "1.7.2",
+    "jquery": "2.2.4",
     "js-cookie": "1.3.1",
     "bootstrap": "2.3.2"
   }


### PR DESCRIPTION
CVE-2015-9251 の警告を消すために段階的にjQueryを更新しようかと思います。
いきなり3系に上げれるとよかったですが、動かなくなるのでとりあえずは2系にしてワークアラウンドを当てました。(再現方法があるかは知らないのと、更にrailsgirls.jpでは難しい気がしますが一応