### PR TITLE
Upgrade HTTP to HTTPS where possible

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
 Creative Commons Attribution-Share Alike 3.0 License.
-http://creativecommons.org/licenses/by-sa/3.0
+https://creativecommons.org/licenses/by-sa/3.0

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,12 +1,12 @@
     <footer>
       <p>
         This work is licensed under a
-        <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-Share Alike 3.0 License</a>
+        <a href="https://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-Share Alike 3.0 License</a>
       </p>
       <p>
         <a href="http://railsgirls.com">Rails Girls</a>
         &middot; Crafted with excitement from Helsinki, Finland &middot; Follow us on
-        <a href="http://twitter.com/railsgirls">Twitter</a>
+        <a href="https://twitter.com/railsgirls">Twitter</a>
         and
         <a href="https://www.facebook.com/railsgirls">Facebook</a>
       </p>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,7 @@
   <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
   <script src="/js/prefixfree.min.js"></script>
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js" type="text/javascript"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js" type="text/javascript"></script>
   <script>
     jQuery.ajaxPrefilter( function( s ) {
       if ( s.crossDomain ) {

--- a/_posts/2012-08-12-how-to-get-rails-girls-started.markdown
+++ b/_posts/2012-08-12-how-to-get-rails-girls-started.markdown
@@ -35,7 +35,7 @@ Rails Girls Tokyoの場合、原田が言い始めたところ、かくたにさ
 #### 2. Rails Girlsメーリングリストに参加する
 <br/>
 イベント開催の情報を流し合うメーリングリストに参加する。MLは英語。
-[http://groups.google.com/group/rails-girls-team?hl=en](http://groups.google.com/group/rails-girls-team?hl=en)
+[https://groups.google.com/group/rails-girls-team?hl=en](http://groups.google.com/group/rails-girls-team?hl=en)
 <br/>
 必ずしも参加しなくていいかもしれない。質問などは、直接 contact@railsgirls.comに投げてもいいので。
 <br/>


### PR DESCRIPTION
👋 Hello Rails Girls JP, I was able to upgrade a couple `HTTP` links to `HTTPS` (part of https://github.com/railsgirls-jp/railsgirls-jp.github.io/issues/377).

For example this Google JS include, before (current):
<img width="539" alt="screen shot 2018-10-18 at 20 14 27" src="https://user-images.githubusercontent.com/1557529/47150787-a53e5d80-d312-11e8-9793-6b3ca4a792c2.png">

After (this PR):
<img width="588" alt="screen shot 2018-10-18 at 20 14 59" src="https://user-images.githubusercontent.com/1557529/47150804-b5eed380-d312-11e8-92c8-40d3fd67f042.png">

Note, this doesn't change the domain to use HTTPS. That's some GitHub/certificate level stuff I don't have access to.