### PR TITLE
クラウドIDEだとheroku openに失敗するため、URLを再確認しやすいように修正

### DIFF
--- a/_posts/2012-04-19-heroku.markdown
+++ b/_posts/2012-04-19-heroku.markdown
@@ -213,10 +213,16 @@ Password for 'https://git.heroku.com':   ← 上でコピーした文字列を�
 heroku run rails db:migrate
 {% endhighlight %}
 
-そのコマンドが実行されたら、 url でアプリを見ることができます。このアプリの例では、 [http://evening-sky-7498.herokuapp.com/](http://evening-sky-7498.herokuapp.com) です。もしくは、ターミナルで次のコマンドを実行すれば、そのページを見に行くことができます。
+そのコマンドが実行されたら、インターネットからアプリを見ることができます。このアプリの例ではURLは、 [http://evening-sky-7498.herokuapp.com/](http://evening-sky-7498.herokuapp.com) です。もしくは、クラウドIDE以外ならターミナルで次のコマンドを実行すれば、そのページを見に行くことができます。
 
 {% highlight sh %}
 heroku open
+{% endhighlight %}
+
+もし、これまでに出てきたコマンドの実行中に表示されるURLを見逃していた場合は、以下のコマンドを実行した時の `Web URL` の行(最後の行)を確認してください。
+
+{% highlight sh %}
+heroku apps:info
 {% endhighlight %}
 
 #### おわりに


### PR DESCRIPTION
クラウドIDEだとheroku openは失敗するので一言加えたのと、(コーチの人が付いてれば既出のURLを教えてくれる気はしますが、)URLの再確認の方法を追記しました。

heroku openに失敗すると `Manually visit ... in your browser. ` と表示されるのでそれを書こうかと最初思ったんですけど、URLの話が2回出てくる事になるのでやめました。