### PR TITLE
Use HTTPS for all Google Groups links

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Official website and blog for Rails Girls movement can be found at http://railsg
 
 ## E-mail list
 
-Global mailing list for Rails Girls events at http://groups.google.com/group/rails-girls-team
+Global mailing list for Rails Girls events at https://groups.google.com/group/rails-girls-team
 
 ## Credits
 

--- a/_posts/2012-04-18-guide.markdown
+++ b/_posts/2012-04-18-guide.markdown
@@ -517,7 +517,7 @@ Rails Girlsは定期的に blog.railsgirls.com を更新しています。
 - フォローアップのイベントに興味をもったら、
 
 何かアイディアがあれはそれを、あるいは Rails Girls チームのためにボランティアをしたいと思ったら、
-お知らせください。グループのメーリングリスト http://groups.google.com/group/rails-girls-team に
+お知らせください。グループのメーリングリスト https://groups.google.com/group/rails-girls-team に
 登録してください！
 
 以上です。

--- a/_posts/2012-08-12-how-to-get-rails-girls-started.markdown
+++ b/_posts/2012-08-12-how-to-get-rails-girls-started.markdown
@@ -35,7 +35,7 @@ Rails Girls Tokyoの場合、原田が言い始めたところ、かくたにさ
 #### 2. Rails Girlsメーリングリストに参加する
 <br/>
 イベント開催の情報を流し合うメーリングリストに参加する。MLは英語。
-[https://groups.google.com/group/rails-girls-team?hl=en](http://groups.google.com/group/rails-girls-team?hl=en)
+[https://groups.google.com/group/rails-girls-team?hl=en](https://groups.google.com/group/rails-girls-team?hl=en)
 <br/>
 必ずしも参加しなくていいかもしれない。質問などは、直接 contact@railsgirls.comに投げてもいいので。
 <br/>


### PR DESCRIPTION
Address https://github.com/railsgirls-jp/railsgirls-jp.github.io/pull/386#discussion_r227167492 and upgrades all remaining Google Groups links to HTTPS.