### PR TITLE
Add heroku toolbelt on codenvy.

### DIFF
--- a/_posts/2012-04-19-heroku.markdown
+++ b/_posts/2012-04-19-heroku.markdown
@@ -52,6 +52,14 @@ brew install heroku/brew/heroku
 
 （環境により拡張子が表示されませんが、異常ではありません）
 
+##### codenvy.ioの場合
+
+codenvy.io上のターミナルから次のコマンドを入力しましょう。
+
+{% highlight sh %}
+curl https://cli-assets.heroku.com/install.sh | sh
+{% endhighlight %}
+
 #### Heroku にコマンドラインでログインしよう
 
 Heroku Toolbelt を無事インストールできたら、ターミナル（Mac）またはコマンドプロンプト（Windows）を起動して、次のコマンドを入力しましょう。


### PR DESCRIPTION
heroku toolbeltのインスト-ルにcodenvyがなかったため追加しました。後日cloud9にも追加しようと思います。