### PR TITLE
Fix devise docs for Rails 5.2

### DIFF
--- a/_posts/2012-11-01-devise.markdown
+++ b/_posts/2012-11-01-devise.markdown
@@ -127,7 +127,7 @@ Rails のサーバーが起動している事を確認したら、[http://localh
   before_action :authenticate_user!
 {% endhighlight %}
 
-`protect_from_forgery with: :exception` と書かれているところの後に追加してください。
+`end` と書かれているところの前に追加してください。
 
 ブラウザを開いてログインやログアウトを試してみてください。
 


### PR DESCRIPTION
Rails 5.2 では ApplicationController に `protect_from_forgery with: :exception` が含まれなくなったので記載を変更しました。

![devise](https://user-images.githubusercontent.com/149772/48353550-0fa8aa80-e6d3-11e8-9615-7e5d735b8837.jpeg)