### PR TITLE
fix form view on app docs for Rails 5.2.1

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -216,13 +216,13 @@ mount_uploader :picture, PictureUploader
 を追加します。さらに、`app/views/ideas/_form.html.erb` を開いて次のように編集します。
 
 {% highlight erb %}
-<%= form.text_field :picture, id: :idea_picture %>
+<%= form.text_field :picture %>
 {% endhighlight %}
 
 &nbsp;&nbsp;&#8595;
 
 {% highlight erb %}
-<%= form.file_field :picture, id: :idea_picture %>
+<%= form.file_field :picture %>
 {% endhighlight %}
 
 場合によっては、 *TypeError: can't cast ActionDispatch::Http::UploadedFile to string* というエラーが起きることもあります。エラーになった場合は、 `app/views/ideas/_form.html.erb` の


### PR DESCRIPTION
Rails 5.2.1から `ActionView::Helpers::FormHelper.form_with_generates_ids` が default trueになり、
出力される`_from.html.erb` が変わったため、記載を変更しました。

#387