### PR TITLE
gem install bundler の説明を削除

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -92,13 +92,7 @@ cp /usr/local/opt/curl-ca-bundle/share/ca-bundle.crt `ruby -ropenssl -e 'puts Op
 rbenv global 2.6.1
 {% endhighlight %}
 
-#### 3-6. Bundlerのインストール:
-
-{% highlight sh %}
-gem install bundler --no-document
-{% endhighlight %}
-
-#### 3-7. Railsのインストール:
+#### 3-6. Railsのインストール:
 
 {% highlight sh %}
 gem install rails --no-document


### PR DESCRIPTION
https://github.com/railsgirls-jp/railsgirls-jp.github.io/pull/426 により `gem install bundler` の説明いらなくなったのではと思ったのでPRです。

問題ないことを確認しています。
```shell
$ rbenv install 2.6.1
ruby-build: use openssl from homebrew
Downloading ruby-2.6.1.tar.bz2...
-> https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.bz2
Installing ruby-2.6.1...
ruby-build: use readline from homebrew
Installed ruby-2.6.1 to /Users/minamiya/.anyenv/envs/rbenv/versions/2.6.1

$ ruby -v
ruby 2.6.1p33 (2019-01-30 revision 66950) [x86_64-darwin18]
$ gem install rails --no-document
Fetching i18n-1.5.3.gem
Fetching rack-test-1.1.0.gem
Fetching mini_portile2-2.4.0.gem
Fetching rack-2.0.6.gem
--snip--
```

(とは言えあった方が「昔はこうしなければいけなくてのぅ…。」という話ができるのでこのままでもいいかもしれません…。)