### PR TITLE
More remove gem install bundler section

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -525,19 +525,13 @@ rbenv install 2.6.1
 rbenv global 2.6.1
 {% endhighlight %}
 
-### *6.* Bundlerのインストール
-
-{% highlight sh %}
-gem install bundler --no-document
-{% endhighlight %}
-
-### *7.* Railsのインストール
+### *6.* Railsのインストール
 
 {% highlight sh %}
 gem install rails --no-document
 {% endhighlight %}
 
-#### *8.* 開発する
+#### *7.* 開発する
 
 * 左側はフォルダとファイルを表示、選択できます。
 * 中央部はエディタです。ここでファイルを編集します。
@@ -634,13 +628,7 @@ rbenv install 2.6.1
 rbenv global 2.6.1
 {% endhighlight %}
 
-#### *4-4* Bundler のインストール
-
-{% highlight sh %}
-gem install bundler --no-document
-{% endhighlight %}
-
-#### *4-5* Rails のインストール
+#### *4-4* Rails のインストール
 
 {% highlight sh %}
 gem install rails --no-document

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -531,7 +531,7 @@ rbenv global 2.6.1
 gem install rails --no-document
 {% endhighlight %}
 
-#### *7.* 開発する
+### *7.* 開発する
 
 * 左側はフォルダとファイルを表示、選択できます。
 * 中央部はエディタです。ここでファイルを編集します。


### PR DESCRIPTION
https://github.com/railsgirls-jp/railsgirls-jp.github.io/pull/427#issuecomment-459907470 でご指摘いただいた件です。

Cloud9 と codenvy.io のセクションからgem install bundler の説明を削除するPRです。
また Cloud9 セクションの軽微な見た目の修正も行っています。