### PR TITLE
Bump to Ruby 2.6.2

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -76,7 +76,7 @@ source ~/.bash_profile
 "rbenv install -l" コマンドでrbenvでインストール可能なRubyのバージョンを確認できます。
 
 {% highlight sh %}
-rbenv install 2.6.1
+rbenv install 2.6.2
 {% endhighlight %}
 
 ※もしも "OpenSSL::SSL::SSLError: ... : certificate verify failed" エラーが起きた場合は、以下の手順を試してみてください。
@@ -89,7 +89,7 @@ cp /usr/local/opt/curl-ca-bundle/share/ca-bundle.crt `ruby -ropenssl -e 'puts Op
 #### 3-5. デフォルトのRuby を設定:
 
 {% highlight sh %}
-rbenv global 2.6.1
+rbenv global 2.6.2
 {% endhighlight %}
 
 #### 3-6. Railsのインストール:
@@ -203,14 +203,14 @@ Bashウィンドウで以下のコマンドを実行してください。
 {% highlight sh %}
 git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
 {% endhighlight %}
-  
+
 #### 2-4 Rubyのインストール
 
 Bashウィンドウで以下のコマンドを実行してください。
 
 {% highlight sh %}
-rbenv install 2.6.1
-rbenv global 2.6.1
+rbenv install 2.6.2
+rbenv global 2.6.2
 {% endhighlight %}
 
 作業完了後に、以下のコマンドを実行してください。
@@ -222,7 +222,7 @@ ruby -v
 以下のように、インストールされたRubyのバージョンが表示されればOKです。
 
 {% highlight sh %}
-ruby 2.6.1p33 (2019-01-30 revision 66950) [x86_64-linux]
+ruby 2.6.2p47 (2019-03-13 revision 67232) [x86_64-linux]
 {% endhighlight %}
 
 ### *3.* Railsのインストール
@@ -242,7 +242,7 @@ rails -v
 以下のように、インストールされたRailsのバージョンが表示されればOKです（バージョンの番号は違うかもしれません）。
 
 {% highlight sh %}
-Rails 5.2.2
+Rails 5.2.2.1   
 {% endhighlight %}
 
 <hr />
@@ -251,7 +251,7 @@ Rails 5.2.2
 
 このワークショップでは Atom エディタを推奨しています。
 
-* [Atom エディタをダウンロードしてインストールする](https://atom.io/) 
+* [Atom エディタをダウンロードしてインストールする](https://atom.io/)
 
 ### *5.* 動作確認
 
@@ -309,7 +309,7 @@ rails -v
 以下のように、インストールされたRailsのバージョンが表示されればOKです（バージョンの番号は違うかもしれません）。
 
 {% highlight sh %}
-Rails 5.2.2
+Rails 5.2.2.1
 {% endhighlight %}
 
 もしもRailsのバージョンが5.2よりも小さい場合は 以下のコマンドを実行することでバージョンアップできます。
@@ -551,7 +551,7 @@ Cloud9を再起動して `$GEM_HOME`, `$GEM_PATH` を更新します。
 ### *5.* rbenv を使って Ruby の version を最新にする
 
 "ruby -v" コマンドでRubyのバージョンを確認できます。
-最新の2.6.1では無い場合は2.6.1をインストールしましょう。
+最新の2.6.2では無い場合は2.6.2をインストールしましょう。
 
 {% highlight sh %}
 git clone https://github.com/rbenv/rbenv.git ~/.rbenv
@@ -559,8 +559,8 @@ git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 echo 'PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bash_profile
 echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
 source ~/.bash_profile
-rbenv install 2.6.1
-rbenv global 2.6.1
+rbenv install 2.6.2
+rbenv global 2.6.2
 {% endhighlight %}
 
 ### *6.* Bundlerのインストール
@@ -648,7 +648,7 @@ sudo apt-get update -y && sudo apt-get install -y build-essential bzip2 libsqlit
 インストールの途中、入力をする必要があります。以下のように入力して下さい。
 * `Geographic area: ` では `6` (`Asia`) を入力します。
 * `[More]` ではリターン（エンター）キーを押します。
-`[Time zone:]` では `78` (`Tokyo`) を入力します。 
+`[Time zone:]` では `78` (`Tokyo`) を入力します。
 
 #### *4-1* rbenv と ruby-build をインストール
 
@@ -663,13 +663,13 @@ source ~/.bashrc
 #### *4-2* rbenv を使って Ruby をインストール
 
 {% highlight sh %}
-rbenv install 2.6.1
+rbenv install 2.6.2
 {% endhighlight %}
 
 #### *4-3* デフォルトの Ruby を設定
 
 {% highlight sh %}
-rbenv global 2.6.1
+rbenv global 2.6.2
 {% endhighlight %}
 
 #### *4-4* Bundler のインストール


### PR DESCRIPTION
- 各環境のRubyバージョンを2.6.2にしました
- Railsバージョンが5.2.2と書かれたところがあったので5.2.2.1にしました
- https://www.ruby-lang.org/en/news/2019/03/13/ruby-2-6-2-released/

https://github.com/railsgirls-jp/railsgirls-jp.github.io/pull/426 みたいです。

[私のRailsGirlsアプリ](https://github.com/larouxn/carrotgram)でRuby2.6.2+Rails5.2.2.1でappとherokuへpushまで動作確認できました。