### PR TITLE
Bump to Ruby 2.6.3

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -76,7 +76,7 @@ source ~/.bash_profile
 "rbenv install -l" コマンドでrbenvでインストール可能なRubyのバージョンを確認できます。
 
 {% highlight sh %}
-rbenv install 2.6.2
+rbenv install 2.6.3
 {% endhighlight %}
 
 ※もしも "OpenSSL::SSL::SSLError: ... : certificate verify failed" エラーが起きた場合は、以下の手順を試してみてください。
@@ -89,7 +89,7 @@ cp /usr/local/opt/curl-ca-bundle/share/ca-bundle.crt `ruby -ropenssl -e 'puts Op
 #### 3-5. デフォルトのRuby を設定:
 
 {% highlight sh %}
-rbenv global 2.6.2
+rbenv global 2.6.3
 {% endhighlight %}
 
 #### 3-6. Railsのインストール:
@@ -209,8 +209,8 @@ git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-b
 Bashウィンドウで以下のコマンドを実行してください。
 
 {% highlight sh %}
-rbenv install 2.6.2
-rbenv global 2.6.2
+rbenv install 2.6.3
+rbenv global 2.6.3
 {% endhighlight %}
 
 作業完了後に、以下のコマンドを実行してください。
@@ -222,7 +222,7 @@ ruby -v
 以下のように、インストールされたRubyのバージョンが表示されればOKです。
 
 {% highlight sh %}
-ruby 2.6.2p47 (2019-03-13 revision 67232) [x86_64-linux]
+ruby 2.6.3p62 (2019-04-16 revision 67580) [x86_64-linux]
 {% endhighlight %}
 
 ### *3.* Railsのインストール
@@ -551,7 +551,7 @@ Cloud9を再起動して `$GEM_HOME`, `$GEM_PATH` を更新します。
 ### *5.* rbenv を使って Ruby の version を最新にする
 
 "ruby -v" コマンドでRubyのバージョンを確認できます。
-最新の2.6.2では無い場合は2.6.2をインストールしましょう。
+最新の2.6.3では無い場合は2.6.3をインストールしましょう。
 
 {% highlight sh %}
 git clone https://github.com/rbenv/rbenv.git ~/.rbenv
@@ -559,8 +559,8 @@ git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 echo 'PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bash_profile
 echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
 source ~/.bash_profile
-rbenv install 2.6.2
-rbenv global 2.6.2
+rbenv install 2.6.3
+rbenv global 2.6.3
 {% endhighlight %}
 
 ### *6.* Bundlerのインストール
@@ -663,13 +663,13 @@ source ~/.bashrc
 #### *4-2* rbenv を使って Ruby をインストール
 
 {% highlight sh %}
-rbenv install 2.6.2
+rbenv install 2.6.3
 {% endhighlight %}
 
 #### *4-3* デフォルトの Ruby を設定
 
 {% highlight sh %}
-rbenv global 2.6.2
+rbenv global 2.6.3
 {% endhighlight %}
 
 #### *4-4* Bundler のインストール


### PR DESCRIPTION
Ruby 2.6.3 がリリースされました。

- [リリースの発表](https://www.ruby-lang.org/en/news/2019/04/17/ruby-2-6-3-released/)
- [Release announcement](https://www.ruby-lang.org/ja/news/2019/04/17/ruby-2-6-3-released/)

https://github.com/railsgirls-jp/railsgirls-jp.github.io/pull/441 みたいです。

[私のRailsGirlsアプリ](https://github.com/larouxn/carrotgram/pull/5)でRuby2.6.3+Rails5.2.3でappとherokuへpushまで動作確認できました。