### PR TITLE
move Nagano 1st to past events

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -8,6 +8,10 @@ title: "Rails Girls Events"
 <div id="container" class="row clearfix">
   <h2>過去のイベント</h2>
 
+  <a href="http://railsgirls.com/nagano" class="span4 event" style="background: url(http://railsgirls.com/images/nagano/rg-nagano-1st.png) center 0 / 40% no-repeat;">
+    <h3>Nagano<small>2019/05/24-25</small></h3>
+  </a>
+
   <a href="http://railsgirls.com/tokyo-2019-02-22.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-tokyo-2019-02-22.png) 90px 5px / 40% no-repeat;">
     <h3>Tokyo<small>2019/02/22-23</small></h3>
   </a>

--- a/index.html
+++ b/index.html
@@ -24,9 +24,6 @@ title: 日本語版ガイド
 <h2>日本で近日開催のイベント</h2>
 
 <div id="container" class="row clearfix">
-  <a href="http://railsgirls.com/nagano" class="span4 event" style="background: url(http://railsgirls.com/images/nagano/rg-nagano-1st.png) center 0 / 40% no-repeat;">
-    <h3>Nagano<small>2019/05/24-25</small></h3>
-  </a>
   <a href="http://railsgirls.com/ehime" class="span4 event" style="background: url(http://railsgirls.com/images/rg-ehime.png) 90px 5px / 40% no-repeat;">
     <h3>Ehime<small>2019/06/14-15</small></h3>
   </a>

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -97,6 +97,7 @@ title: Rails Girls Japan Sponsors
 <h2>2019年</h2>
 <h4>年間スポンサー</h4>
   <div class="year-sponsor">
+    <a class="year-sponsor" href="https://esa.io/"><img src="http://railsgirls.com/images/japan/esa.png" alt="esa LLC" ></a>
     <a class="year-sponsor" href="http://www.lmi.ne.jp/"><img src="/images/lmi_logo.jpg" alt="Link and Motivation Inc." ></a>
     <a class="year-sponsor" href="https://www.esm.co.jp/"><img src="http://railsgirls.com/images/set-baseE_Y.png" alt="Eiwa System Management" ></a>
     <a class="year-sponsor" href="https://github.com/"><img src="http://railsgirls.com/images/clt/github_logo.png" alt="github"></a>

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -208,7 +208,6 @@ title: Rails Girls Japan Sponsors
         <a class="event-sponsor" href="https://smarthr.jp/"><img src="http://railsgirls.com/images/smarthr.png" alt="SmartHR"></a>
         <a class="event-sponsor" href="https://jp.corp-sansan.com/"><img src="http://railsgirls.com/images/eight_new_logo.png" alt="Eight"></a>
         <a class="event-sponsor" href="https://everyleaf.com/"><img src="http://railsgirls.com/images/everyleaf-logo.png" alt="Everyleaf"></a>
-        <a class="event-sponsor" href="https://potepan.jp/"><img src="http://railsgirls.com/images/PCLOGO_03.png" alt="Potepan"></a>
         <a class="event-sponsor" href="https://kinarino.jp/"><img src="http://railsgirls.com/images/kinarino.png" alt="kinarino"></a>
         <a class="event-sponsor" href="https://cloud.google.com/"><img src="http://railsgirls.com/images/googlecloud.png" alt="Google Cloud"></a>
         <a class="event-sponsor" href="https://bootcamp.fjord.jp/"><img src="http://railsgirls.com/images/fjord_small.png" alt="Fjord"></a>

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -105,6 +105,24 @@ title: Rails Girls Japan Sponsors
 
 <h4>イベントスポンサー</h4>
   <div class="event-box">
+    <p><a href="http://railsgirls.com/nagano">Nagano 1st</a></p>
+    <div class="event-sponsor">
+      <a class="event-sponsor" href="http://www.n-bisen.ac.jp/">
+        <img src="http://railsgirls.com/images/nagano/n-bisen.png" alt="Nagano Bisen">
+      </a>
+      <a class="event-sponsor" href="https://pepabo.com/">
+        <img src="http://railsgirls.com/images/japan/pepabo.png" alt="GMO Pepabo">
+      </a>
+      <a class="event-sponsor" href="http://www.carrot.co.jp/">
+        <img src="http://railsgirls.com/images/KCSC.png" alt="KCS Carrot">
+      </a>
+      <a class="event-sponsor" href="https://www.shiolab.com/">
+        <img src="http://railsgirls.com/images/nagano/shiolab.png" alt="Shiolab">
+      </a>
+    </div>
+  </div>
+
+  <div class="event-box">
     <p><a href="http://railsgirls.com/tokyo.html">Tokyo 11th</a></p>
     <div class="event-sponsor">
       <a class="event-sponsor" href="https://company.finc.com/"><img src="http://railsgirls.com/images/japan/finc.png" alt="FiNC Technologies"></a>


### PR DESCRIPTION
5/24, 25 に無事開催しました！
ありがとうございました！

あわせて、以下の対応も行っています。
- esaさまを年間スポンサーに追加
- Sponsorsページに Tokyo 10th の削除したスポンサーが残っていたので削除