### PR TITLE
add 2019 sponsors

### DIFF
--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -97,6 +97,10 @@ title: Rails Girls Japan Sponsors
 <h2>2019年</h2>
 <h4>年間スポンサー</h4>
   <div class="year-sponsor">
+    <a class="year-sponsor" href="https://jp.corp-sansan.com/"><img src="http://railsgirls.com/images/eight_new_logo.png" alt="Eight" ></a>
+    <a class="year-sponsor" href="https://smarthr.jp/"><img src="http://railsgirls.com/images/smarthr.png" alt="SmartHR"></a>
+    <a class="year-sponsor" href="https://medpeer.co.jp"><img src="http://railsgirls.com/images/japan/MedPeer_logo.png" alt="MedPeer"></a>
+    <a class="year-sponsor" href="https://aktsk.jp/"><img src="http://railsgirls.com/images/japan/aktsk_log_yoko.png" alt="Akatsuki Inc."></a>
     <a class="year-sponsor" href="https://esa.io/"><img src="http://railsgirls.com/images/japan/esa.png" alt="esa LLC" ></a>
     <a class="year-sponsor" href="http://www.lmi.ne.jp/"><img src="/images/lmi_logo.jpg" alt="Link and Motivation Inc." ></a>
     <a class="year-sponsor" href="https://www.esm.co.jp/"><img src="http://railsgirls.com/images/set-baseE_Y.png" alt="Eiwa System Management" ></a>


### PR DESCRIPTION
2019年 スポンサーロゴを追加しました。
本家サイトのロゴを参照しているので、 https://github.com/railsgirls/railsgirls/pull/1837 がマージされたら、WIP外します。