### PR TITLE
Workaround for timeout executing heroku run 

### DIFF
--- a/_posts/2012-04-19-heroku.markdown
+++ b/_posts/2012-04-19-heroku.markdown
@@ -237,6 +237,8 @@ Password for 'https://git.heroku.com':   ← 上でコピーした文字列を�
 heroku run rails db:migrate
 {% endhighlight %}
 
+公共のネットワークなどを使った場合、`ETIMEDOUT: connect ETIMEDOUT (IPアドレス):5000` というエラーが起きることがあります。エラーになった場合は実行するコマンドを `heroku run:detached rails db:migrate` に変更してみてください。
+
 そのコマンドが実行されたら、インターネットからアプリを見ることができます。このアプリの例ではURLは、 [http://my-first-app.herokuapp.com/](http://my-first-app.herokuapp.com) です。もしくは、クラウドIDE以外ならターミナルで次のコマンドを実行すれば、そのページを見に行くことができます。
 
 {% highlight sh %}


### PR DESCRIPTION
https://github.com/railsgirls-jp/coach.info/issues/29 に記載した内容です

`heroku run` を実行した際、コマンドの実行結果を表示するために heroku の 5000番ポートに接続しにいくようです。
ファイアウォールなどでこのポートへの接続が閉じられている場合に `ETIMEDOUT: connect ETIMEDOUT (IPアドレス):5000` というエラーがでるので、その回避策を追記しました。

https://devcenter.heroku.com/articles/one-off-dynos#troubleshooting