### PR TITLE
Move to past events Sendai 2nd

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -7,6 +7,11 @@ title: "Rails Girls Events"
 
 <div id="container" class="row clearfix">
   <h2>過去のイベント</h2>
+
+  <a href="http://railsgirls.com/sendai" class="span4 event" style="background: url(http://railsgirls.com/images/rg-sendai-2019-07-20.png) 90px 5px / 40% no-repeat;">
+    <h3>Sendai<small>2019/07/19-20</small></h3>
+  </a>
+
   <a href="http://railsgirls.com/osaka" class="span4 event" style="background: url(http://railsgirls.com/images/osaka/rg-osaka6th.png) 90px 5px / 40% no-repeat;">
     <h3>Osaka<small>2019/06/21-22</small></h3>
   </a>

--- a/index.html
+++ b/index.html
@@ -24,9 +24,6 @@ title: 日本語版ガイド
 <h2>日本で近日開催のイベント</h2>
 
 <div id="container" class="row clearfix">
-  <a href="http://railsgirls.com/sendai" class="span4 event" style="background: url(http://railsgirls.com/images/rg-sendai-2019-07-20.png) 90px 5px / 40% no-repeat;">
-    <h3>Sendai<small>2019/07/19-20</small></h3>
-  </a>
   <a href="http://railsgirls.com/tokyo" class="span4 event" style="background: url(http://railsgirls.com/images/rg-tokyo-2019-08-02.png) 90px 5px / 40% no-repeat;">
     <h3>Tokyo<small>2019/08/02-03</small></h3>
   </a>

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -196,7 +196,7 @@ title: Rails Girls Japan Sponsors
         <a class="event-sponsor" href="https://www.membersedge.co.jp/"><img src="http://railsgirls.com/images/sendai/members_edge.png" alt="MEMBERS EDGE"></a>
         <a class="event-sponsor" href="https://4growth.jp/"><img src="http://railsgirls.com/images/sendai/4growth.png" alt="4Growth"></a>
         <a class="event-sponsor" href="http://www.mwed.co.jp/"><img src="http://railsgirls.com/images/mwed_logo.jpg" alt="みんなのウェディング"></a>
-        <a class="event-sponsor" href="http://noraya-sendai.net/"><img src="http://railsgirls.com/images/sendai/noraya.png" alt="ノラヤ"></a>
+        <a class="event-sponsor" href="http://noraya-sendai.net/"><img src="http://railsgirls.com/images/sendai/sponsor-1st/noraya.png" alt="ノラヤ"></a>
         <a class="event-sponsor" href="https://pepabo.com/"><img src="http://railsgirls.com/images/fukuoka/pepabo.png" alt="GMO Pepabo"></a>
         <a class="event-sponsor" href="https://ruby-no-kai.org"><img src="http://railsgirls.com/images/ruby-no-kai-long.png" alt="Nihon-Ruby-No-Kai"></a>
       </div>


### PR DESCRIPTION
Sendai 2ndが無事に終了しましたので、Sendai 2ndのリンクを過去のイベント一覧に移動しました。
併せて、sponsors/index.htmlでSendai 1stスポンサー様ロゴのリンク切れがあったので(comの方で画像整理したときに確認漏れてました、すみません…)、そちらの修正も行っています。

お手数ですが、ご確認をお願いいたします。