### PR TITLE
[Rails 6.0.0] mini_magickのバージョンを変更

### DIFF
--- a/_posts/2012-06-03-thumbnails.markdown
+++ b/_posts/2012-06-03-thumbnails.markdown
@@ -30,7 +30,7 @@ gem 'carrierwave'
 の下に
 
 {% highlight ruby %}
-gem 'mini_magick', '4.8.0'
+gem 'mini_magick'
 {% endhighlight %}
 
 を追加します。その後に Terminal で以下のコマンドを実行します。

--- a/_posts/2013-01-20-design.markdown
+++ b/_posts/2013-01-20-design.markdown
@@ -43,7 +43,7 @@ body { padding-top: 60px; }
 下の行を追加します。
 
 {% highlight erb %}
-<li ><%= link_to 'New Idea', new_idea_path %></li>
+<li><%= link_to 'New Idea', new_idea_path %></li>
 {% endhighlight %}
 
 **コーチへ**: 何故 a タグではなく link_to を使うのか説明しましょう
@@ -63,7 +63,7 @@ body { padding-top: 60px; }
   <div class="row">
     <% group.compact.each do |idea| %>
       <div class="col-md-4">
-        <%= image_tag idea.picture_url, width: '100%' if idea.picture.present?%>
+        <%= image_tag idea.picture_url, width: '100%' if idea.picture.present? %>
         <h4><%= link_to idea.name, idea %></h4>
         <%= idea.description %>
       </div>


### PR DESCRIPTION
[Carrierwaveを使ってサムネイルを作ってみよう](http://railsgirls.jp/thumbnails) ページの
Gemfileにmini_magickを追加するときのバージョン指摘をなくしてみました。

Mac 環境で以下のバージョンで動作確認済みです。
- Rails 6.0.0
- Ruby 2.6.4
- imagemagick 7.0.8-59
- mini_magick 4.9.5
