### PR TITLE
Win RubyInstallerを使ったインストール手順をRails6.0.0に対応

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -278,8 +278,7 @@ rails server
 
 ### *1.* Rubyのインストール
 
-[RubyInstaller](https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.6.3-1/rubyinstaller-devkit-2.6.3-1-x64.exe) をダウンロードして実行します。
-
+[RubyInstaller](https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.6.4-1/rubyinstaller-devkit-2.6.4-1-x64.exe) をダウンロードして実行します。
 
 インストールのオプションは `Use UTF-8 as default external encoding` をチェックし、他の選択肢は全てデフォルトを選択します。
 ![RubyInstaller Install options](/images/windows_install/rubyinstaller_install_options.png "rubyinstaller install options")

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -309,7 +309,7 @@ rails -v
 以下のように、インストールされたRailsのバージョンが表示されればOKです（バージョンの番号は違うかもしれません）。
 
 {% highlight sh %}
-Rails 5.2.3
+Rails 6.0.0
 {% endhighlight %}
 
 もしもRailsのバージョンが5.2よりも小さい場合は 以下のコマンドを実行することでバージョンアップできます。
@@ -328,20 +328,17 @@ Windows Vista およびそれ以前のバージョンでは Atom エディタは
 
 これで、Ruby on Railsのプログラミングを始められるまでの環境セットアップは終了です。おめでとう！
 
-### *4.* Install node
+### *4.* JavaScriptライブラリのインストール
 
-これは厳密に言うと必要ではありませんが、 後で起こる可能性のある `ExecJS::RuntimeError` や `オブジェクトでサポートされていないプロパティまたはメソッドです` などの問題を回避してくれます。 ([参考 stackoverflow](https://stackoverflow.com/questions/12520456/execjsruntimeerror-on-windows-trying-to-follow-rubytutorial))
-
-* こちらのサイト [https://nodejs.org/](https://nodejs.org/) から、LTS版をダウンロードし、インストールします。
+* nodeをインストールします。こちらのサイト [https://nodejs.org/](https://nodejs.org/) から、LTS版をダウンロードし、インストールします。
+* yarnをインストールします。こちらのサイト [https://yarnpkg.com/ja/docs/install#windows-stable](https://yarnpkg.com/ja/docs/install#windows-stable) で「Windows」「安定版」が選択されていることを確認し、「インストーラをダウンロードする」ボタンを押します。ダウンロードが完了したら、保存されたインストーラを実行してください。
 * `Command Prompt with Ruby on Rails` をもう一度開いてください。
-
-node のバージョンをチェックしましょう。
+* nodeとyarnのバージョンをチェックしましょう。それぞれ、バージョンが表示されればOKです。
 
 {% highlight sh %}
-node --version
+node -v
+yarn -v
 {% endhighlight %}
-
-バージョンが表示されればOKです。
 
 ### *5.* 動作確認
 

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -346,7 +346,7 @@ yarn -v
 
 *コーチの方へ*:
 
-以下のコマンドでRailsが正しくインストールされているか確認してください。
+以下のコマンドでRailsが正しくインストールされているか確認してください。実行後、ブラウザのURL欄に `http://localhost:3000/books` と入力して、画面が表示されれば成功です。作ったプロジェクトは削除しておきましょう。
 
 {% highlight sh %}
 rails new sample
@@ -356,9 +356,15 @@ rails db:migrate
 rails server
 {% endhighlight %}
 
-ブラウザのURL欄に `http://localhost:3000/books` と入力して、画面が表示されれば成功です。
+bundle install時にsqlite3 gemのインストールでエラーになる場合は、以下を試してみてください。ridkはMSYS2用パッケージマネージャです。
 
-作ったプロジェクトは削除しておきましょう。
+{% highlight sh %}
+gem uninstall sqlite3 --all
+ridk exec pacman -S mingw-w64-x86_64-sqlite3
+gem install sqlite3 --platform ruby
+{% endhighlight %}
+
+rails newで行われるbundle installがエラーで中断したときは、上記の修正後、 bundle install、rails webpacker:install の実行を忘れないでください。
 
 ## 出るかもしれないエラー
 


### PR DESCRIPTION
- Ruby2.6.3 to 2.6.4
- Rails5.2.3 to 6.0.0
- yarn を追加
- インストール時に（おそらく必ず）sqlite3 gem install 時にエラーになるので、解決方法を追記
- 動作確認
  - [x] /installページ
  - [x] /appページ
  - [x] /herokuページ
  - 上記手順で進めてherokuで動けばOK