### PR TITLE
GITチートシートのURLを更新する

### DIFF
--- a/_posts/2013-04-14-github.md
+++ b/_posts/2013-04-14-github.md
@@ -178,7 +178,7 @@ git push origin master
 ### Gitについてもっと学ぶ
 
  * [trygit.org](http://try.github.io/)をチェックアウトする
- * [GITチートシート](https://services.github.com/on-demand/downloads/ja/github-git-cheat-sheet.pdf)を使う
+ * [GITチートシート](https://github.github.com/training-kit/downloads/ja/github-git-cheat-sheet/)([PDF](https://github.github.com/training-kit/downloads/ja/github-git-cheat-sheet.pdf))を使う
  * [git-scm.org](http://git-scm.com/)でGitコマンドを眺めてみる
 
 


### PR DESCRIPTION
[GitHubに自分のアプリをPushする](http://railsgirls.jp/github) にて、
GITチートシートのPDF https://services.github.com/on-demand/downloads/ja/github-git-cheat-sheet.pdf が読み込めなくなっていたので修正しました。

ref: https://github.com/railsgirls/railsgirls.github.io/pull/413