### PR TITLE
rails webpacker:installを動作確認に追加した

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -119,6 +119,7 @@ rails new sample
 cd sample
 rails g scaffold book
 rails db:migrate
+rails webpacker:install
 rails server
 {% endhighlight %}
 
@@ -280,6 +281,7 @@ cd sample
 rails g scaffold book
 rails db:create
 rails db:migrate
+rails webpacker:install
 rails server
 {% endhighlight %}
 
@@ -366,6 +368,7 @@ rails new sample
 cd sample
 rails g scaffold book
 rails db:migrate
+rails webpacker:install
 rails server
 {% endhighlight %}
 
@@ -707,6 +710,7 @@ rails new sample
 cd sample
 bundle exec rails g scaffold book
 bundle exec rails db:migrate
+bundle exec rails webpacker:install
 bundle exec rails server -b 0.0.0.0
 {% endhighlight %}
 


### PR DESCRIPTION
macOSでRails 6の場合 `rails webpacker:install` を行わずに `rails server` した場合以下のようなエラーが発生しました

```
/Users/sei/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/configuration.rb:91:in `rescue in load': Webpacker configuration file not found /Users/sei/sample/config/webpacker.yml. Please run rails webpacker:install Error: No such file or directory @ rb_sysopen - /Users/sei/sample/config/webpacker.yml (RuntimeError)
```

インストール手順の各所に追加しましたが自分ではmacOSのみしか確認できていません