### PR TITLE
Add `~> 1.4` to `sqlite3` section in heroku page

### DIFF
--- a/_posts/2012-04-19-heroku.markdown
+++ b/_posts/2012-04-19-heroku.markdown
@@ -106,14 +106,14 @@ __Coachより__: バージョン管理システムと git について説明す�
 まず、 Heroku で動くデータベースが必要です。いつものデータベースとは違います。 Gemfile を次のように変更しましょう。 :
 
 {% highlight ruby %}
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.4'
 {% endhighlight %}
 
 ↓
 
 {% highlight ruby %}
 group :development do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.4'
 end
 group :production do
   gem 'pg'


### PR DESCRIPTION
Rails 6 changes its dependencies from `sqlite` to `sqlite ~> 1.4`