### PR TITLE
Fix broken link address.

### DIFF
--- a/_posts/2013-03-26-coach.markdown
+++ b/_posts/2013-03-26-coach.markdown
@@ -90,5 +90,5 @@ Rails Girls のコーチによるその他の有益な体験型の情報は以�
 - [What I learned learning Rails / becoming a better teacher](http://floordrees.tumblr.com/post/58784746482/what-i-learned-learning-rails-becoming-a-better)
 - [Tips for coaching a programming study group](http://coaching.rubymonstas.org/)
 
-[app]: http://railsgirls.jp/app/
-[install]: http://railsgirls.jp/install/
+[app]: http://railsgirls.jp/app
+[install]: http://railsgirls.jp/install


### PR DESCRIPTION
Fixed broken link address in [`/coach`](https://railsgirls.jp/coach) pages.
e.g. `チュートリアル` links