### PR TITLE
Rails6.0をインストールするので、バージョンアップの条件を修正

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -331,7 +331,7 @@ rails -v
 Rails 6.0.2.1
 {% endhighlight %}
 
-もしもRailsのバージョンが5.2よりも小さい場合は 以下のコマンドを実行することでバージョンアップできます。
+もしもRailsのバージョンが6.0よりも小さい場合は 以下のコマンドを実行することでバージョンアップできます。
 
 {% highlight sh %}
 gem update rails --no-document


### PR DESCRIPTION
5.2ではなく6.0より小さい場合にバージョンアップが必要。