### PR TITLE
update node install on wsl

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -204,8 +204,8 @@ sudo apt install autoconf bison build-essential libssl1.0-dev libyaml-dev librea
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
 source ~/.bashrc
 nvm install --lts
-nvm alias default lts/* # ターミナル再起動時にlts版を使うようにする 
-nvm use default # ターミナルをここで再起動するなら省略可
+nvm alias default lts/*
+nvm use default
 npm install --global yarn
 {% endhighlight %}
 

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -200,8 +200,13 @@ sudo dpkg-reconfigure tzdata
 {% highlight sh %}
 sudo apt update
 sudo apt upgrade -y
-sudo apt install autoconf bison build-essential libssl1.0-dev libyaml-dev libreadline-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev sqlite3 libsqlite3-dev nodejs-dev node-gyp npm -y
-sudo npm install --global yarn
+sudo apt install autoconf bison build-essential libssl1.0-dev libyaml-dev libreadline-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev sqlite3 libsqlite3-dev -y
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
+source ~/.bashrc
+nvm install --lts
+nvm alias default lts/* # ターミナル再起動時にlts版を使うようにする 
+nvm use default # ターミナルをここで再起動するなら省略可
+npm install --global yarn
 {% endhighlight %}
 
 #### 2-2 rbenvのインストール


### PR DESCRIPTION
WSL ubuntu aptで入るnodeのバージョンが古くて、webpackerで以下のエラーが出る。
なので、より新しいnodeを入れる手順に変更。nvmを利用した。

```
Webpacker requires Node.js >= 8.16.0 and you are using 8.10.0
Please upgrade Node.js https://nodejs.org/en/download/
```