### PR TITLE
macOS Catalinaからデフォルトshellがzshに変更になった旨をinstallページへ追記

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -64,6 +64,8 @@ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/
 
 #### 3-3. [rbenv](https://github.com/rbenv/rbenv)をインストール:
 
+macOS Catalinaからデフォルトのshellがbashからzshに変更されています。 `echo $SHELL` を実行した結果が `bin/bash` のようにbashであれば以下のコマンドの通りで問題ありません。もしも結果が `bin/zsh` のようにzshであるときは、以下の `.bash_profile` を `.zshrc` に置き換えて実行してください。
+
 {% highlight sh %}
 brew update
 brew install rbenv


### PR DESCRIPTION
- macOS Catalina をクリーンインストールすると、デフォルトshellがzshになっている（らしい）
  - zshのときに、zshで動くように注意書きを追加しました
- macOS Catalinaでも、前のバージョンからアップグレードの場合はbash（らしい）です
- 環境が入手できず、動作確認ができていません。