### PR TITLE
Change homebrew install command

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -59,7 +59,7 @@ xcode-select --install
 #### 3-2. [Homebrew](http://brew.sh/)をインストール:
 
 {% highlight sh %}
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 {% endhighlight %}
 
 #### 3-3. [rbenv](https://github.com/rbenv/rbenv)をインストール:


### PR DESCRIPTION
Homebrewのインストールコマンドが変わったので、ガイドのインストールページも変更しました。
https://brew.sh/index_ja

ちなみにカタリナがプリインストールされているマシンはデフォルトシェルがzshですが、bashも入っているとのことでした。

背景: https://itchyny.hatenablog.com/entry/2020/03/03/100000