### PR TITLE
WSLでインストールするUbuntuのパッケージを修正

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -205,7 +205,7 @@ sudo dpkg-reconfigure tzdata
 {% highlight sh %}
 sudo apt update
 sudo apt upgrade -y
-sudo apt install autoconf bison build-essential libssl1.0-dev libyaml-dev libreadline-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev sqlite3 libsqlite3-dev -y
+sudo apt install autoconf bison build-essential libssl-dev libyaml-dev libreadline-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev sqlite3 libsqlite3-dev -y
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
 source ~/.bashrc
 nvm install --lts


### PR DESCRIPTION
## 概要

WSLでのインストール手順でインストールするUbuntuパッケージの `libssl1.0-dev` を `libssl-dev`に変更します。

## 詳細

Ubuntu20.04のデフォルトPPAでは`libssl1.0-dev`が存在しません。

```sh
$ cat /etc/issue
Ubuntu 20.04.2 LTS \n \l

$ apt search --names-only libssl
Sorting... Done
Full Text Search... Done
libssl-dev/focal-updates,focal-security,now 1.1.1f-1ubuntu2.2 amd64 [installed]
  Secure Sockets Layer toolkit - development files

libssl-doc/focal-updates,focal-security 1.1.1f-1ubuntu2.2 all
  Secure Sockets Layer toolkit - development documentation

libssl-ocaml/focal 0.5.9-1build1 amd64
  OCaml bindings for OpenSSL (runtime)

libssl-ocaml-dev/focal 0.5.9-1build1 amd64
  OCaml bindings for OpenSSL

libssl-utils-clojure/focal 0.8.3-2 all
  library for SSL certificate management on the JVM

libssl1.1/focal-updates,focal-security,now 1.1.1f-1ubuntu2.2 amd64 [installed]
  Secure Sockets Layer toolkit - shared libraries
```

そのため、次のようなエラーが発生します。

```sh
$ sudo apt install libssl1.0-dev

Reading package lists... Done
Building dependency tree       
Reading state information... Done
Package libssl1.0-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'libssl1.0-dev' has no installation candidate
```

##  対応

 `libssl1.0-dev` を `libssl-dev`に変更します。

```sh
$ sudo apt install libssl-dev
Reading package lists... Done
Building dependency tree       
Reading state information... Done
libssl-dev is already the newest version (1.1.1f-1ubuntu2.2).
The following packages were automatically installed and are no longer required:
  javascript-common libauthen-sasl-perl libc-ares2 libdata-dump-perl libencode-locale-perl libexpat1-dev libfile-basedir-perl 

...

  python3-distlib python3-filelock python3-pip python3-virtualenv python3-virtualenv-clone python3-wheel python3.8-dev x11-xserver-utils xdg-utils
Use 'sudo apt autoremove' to remove them.
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
```

## その他

Ubuntu20.04でしか試していません。（おそらく下位バージョンでは `libssl1.0-dev` でよかったのではないかと思います）
