### PR TITLE
ロゴ画像のリンク先が 404 となっていたので修正

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -37,7 +37,7 @@
   <div class="container">
     <!-- Desktop -->
     <div class="visible-desktop">
-      <a class="span3" href="http://railsgirls-jp.github.com/" id="logo">
+      <a class="span3" href="/" id="logo">
         <img alt="Rails Girls ガイド" src="/images/railsgirls-guides.png">
       </a>
       <nav class="nav pull-right">


### PR DESCRIPTION
ロゴ画像のリンク先が 404 となっていたので修正しました！

```diff
- http://railsgirls-jp.github.com/
+ /
```

![Demo of clicking logo image](http://g.recordit.co/xGFg6S3mtv.gif)