### PR TITLE
move Rails Girls Gathering Japan Event to Past event.

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -7,6 +7,10 @@ title: "Rails Girls Events"
 
 <div id="container" class="row clearfix">
   <h2>過去のイベント</h2>
+  <a href="https://railsgirls-japan.doorkeeper.jp/events/123336" class="span4 event" style="background:url(/images/events/rails-girls-gathering-japan-2021-logo.png) 0px -80px / 100% no-repeat;">
+    <h3>Rails Girls Gathering Japan 2021<small>2021/08/28</small></h3>
+  </a>
+
   <a href="https://qiita.com/advent-calendar/2020/railsgirlsjapan" class="span4 event" style="background:url(http://railsgirls.com/images/railsgirls-sq.png) 0px -70px / 100% no-repeat;">
     <h3>Advent Calendar 2020<small>2020/12/01-25</small></h3>
   </a>

--- a/index.html
+++ b/index.html
@@ -24,9 +24,6 @@ title: 日本語版ガイド
 <h2>日本で近日開催のイベント</h2>
 
 <div id="container" class="row clearfix">
-  <a href="https://railsgirls-japan.doorkeeper.jp/events/123336" class="span4 event" style="background:url(/images/events/rails-girls-gathering-japan-2021-logo.png) 0px -80px / 100% no-repeat;">
-    <h3>Rails Girls Gathering Japan 2021<small>2021/08/28</small></h3>
-  </a>
 </div>
 
 <h2>Rails Girls にようこそ!</h2>


### PR DESCRIPTION
2021/08/28 Rails Girls Gathering Japan 2021の開催が終了したので、
イベント情報をPast Eventsに移動しました！