### PR TITLE
RubyKaigi Takeout 2021 参加支援	Blog 追加

### DIFF
--- a/_posts/blog/2021-08-29-start-accepting-rubykaigi-takeout-2021-support-for-alumni.markdown
+++ b/_posts/blog/2021-08-29-start-accepting-rubykaigi-takeout-2021-support-for-alumni.markdown
@@ -1,0 +1,39 @@
+---
+layout: post
+title: "RubyKaigi Takeout 2021 参加支援募集のお知らせ"
+date: 2021-08-29
+image: /images/railsgirls-sq.png
+---
+Rails Girls Japanでは、2017年よりRails Girlsイベントの参加者の中から、
+RubyKaigiへの参加希望を募り、参加支援を行ってまいりました。
+
+参加支援のご報告:
+<a href="/2017/09/23/rubykaigi2017-support-for-alumni/">2017年</a> /
+<a href="/2018/12/04/rubykaigi2018-support-for-alumni/">2018年</a> /
+<a href="/2019/06/04/rubykaigi2019-support-for-alumni/">2019年</a>
+
+
+今年もRails Girls Japanでは、RubyKaigi Takeout 2021への参加支援を行います。
+<p>RubyKaigi Takeout 2021への参加支援の目的は、
+RubyKaigiという技術的な国際カンファレンスに参加してもらうことで、
+今後のプログラミングに役立てて欲しいということと、Rubyコミュニティの楽しさを体験して欲しいというところにあります。</p>
+
+RubyKaigiとは
+<blockquote>
+  <p>RubyKaigiは、日本で開催されるプログラミング言語Rubyの国際カンファレンスで、海外からも多くのRubyistが参加します。</p>
+
+  <p>2021年は9/9~9/11の3日間、 オンラインで開催されます。 </p>
+
+</blockquote>
+
+[RubyKaigi Takeout 2021](https://rubykaigi.org/2021-takeout)
+
+
+支援を希望される方は、<a href="https://forms.gle/PvESHb8J3q4qeKQq5">こちら</a>の入力フォームから、
+必要事項を記入の上、お申込みください。
+
+応募締切 : 2021/09/05 10:00
+
+選考結果発表 : 2021/09/06
+
+ご応募お待ちしております。

--- a/_posts/blog/2021-08-29-start-accepting-rubykaigi-takeout-2021-support-for-alumni.markdown
+++ b/_posts/blog/2021-08-29-start-accepting-rubykaigi-takeout-2021-support-for-alumni.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "RubyKaigi Takeout 2021 参加支援募集のお知らせ"
-date: 2021-08-29
+date: 2021-09-01
 image: /images/railsgirls-sq.png
 ---
 Rails Girls Japanでは、2017年よりRails Girlsイベントの参加者の中から、

--- a/_posts/blog/2021-08-29-start-accepting-rubykaigi-takeout-2021-support-for-alumni.markdown
+++ b/_posts/blog/2021-08-29-start-accepting-rubykaigi-takeout-2021-support-for-alumni.markdown
@@ -28,12 +28,30 @@ RubyKaigiとは
 
 [RubyKaigi Takeout 2021](https://rubykaigi.org/2021-takeout)
 
+### 支援内容
+
+RubyKaigi Takeout 2021 の参加チケット (すでに購入済みの場合はチケット代金)
+
+### お申し込み方法
 
 支援を希望される方は、<a href="https://forms.gle/PvESHb8J3q4qeKQq5">こちら</a>の入力フォームから、
 必要事項を記入の上、お申込みください。
 
-応募締切 : 2021/09/05 10:00
+応募要件
+* 以下のいずれかの経験を有すること
+  * 過去に Rails Girls イベントをオーガナイズして開催したことがある
+  * 過去に Rails Girls イベントに参加したことがある
+  * 過去に Rails Girls More! のようなフォローアップイベントに参加したことがある
 
-選考結果発表 : 2021/09/06
+    ※ Rails Girls イベントは http://railsgirls.jp/events/ に掲載されているものを指します
+
+* 参加支援費振込のための銀行口座等の情報を Rails Girls Japan メンバーに開示できること
+
+その他
+* blogに掲載するためのRubyKaigi Takeout 2021に参加しての感想の提出をお願いしています。
+
+##### 応募締切 : 2021/09/05 10:00
+##### 選考結果発表 : 2021/09/06
+
 
 ご応募お待ちしております。


### PR DESCRIPTION
RubyKaigi Takeout 2021 参加支援の応募情報をBlogに掲載しました。

募集期間が日曜10:00までと期間が短いため、
マージされたらRails Girls Japan ツイッターアカウントにて通知する予定です。