### PR TITLE
RubyKaigi 2022参加支援blog記事を作成

### DIFF
--- a/_posts/blog/2022-06-29-start-accepting-rubykaigi2022-support-for-alumni.markdown
+++ b/_posts/blog/2022-06-29-start-accepting-rubykaigi2022-support-for-alumni.markdown
@@ -1,0 +1,62 @@
+---
+layout: post
+title: "RubyKaigi 2022 参加支援募集のお知らせ"
+date: 2022-06-29
+image: /images/railsgirls-sq.png
+---
+Rails Girls Japanでは、2017年よりRails Girlsイベントの参加者の中から、
+RubyKaigiへの参加希望を募り、参加支援を行ってまいりました。
+
+参加支援のご報告:
+<a href="/2017/09/23/rubykaigi2017-support-for-alumni/">2017年</a> /
+<a href="/2018/12/04/rubykaigi2018-support-for-alumni/">2018年</a> /
+<a href="/2019/06/04/rubykaigi2019-support-for-alumni/">2019年</a>
+
+今年もRails Girls Japanでは、RubyKaigi 2022への参加支援を行います。
+
+RubyKaigi 2022への参加支援の目的は、
+RubyKaigiという技術的な国際カンファレンスに参加してもらうことで、
+今後のプログラミングに役立てて欲しいということと、
+Rubyコミュニティの楽しさを体験して欲しいというところにあります。
+
+RubyKaigiとは
+<blockquote>
+  <p>
+  RubyKaigiは、日本で開催されるプログラミング言語Rubyの国際カンファレンスで、海外からも多くのRubyistが参加します。<br>
+  2022年は、9/8~9/10の3日間、三重県総合文化センターとオンラインで開催されます。
+  </p>
+</blockquote>
+[RubyKaigi 2022](https://rubykaigi.org/2022/)
+
+
+### 支援内容
+
+* RubyKaigi 2022 の参加チケット(すでに購入済みの場合はチケット代金)
+* 現地参加を希望する場合、居住地から RubyKaigi 2022 会場への交通費、宿泊費(2022/09/07〜2022/09/11の期間内)
+
+### お申し込み方法
+
+支援を希望される方は、<a href="https://forms.gle/4xoXqizJRRY2wyMY6" target="_blank" rel="noopener noreferrer">こちら</a>の入力フォームから、
+必要事項を記入の上、お申込みください。
+
+#### 応募要件
+* 以下のいずれかの経験を有すること<br>
+  ※Rails Girls イベントは [http://railsgirls.jp/events/](http://railsgirls.jp/events/) に掲載されているものを指します
+    * 過去に Rails Girls イベントをオーガナイザー・スタッフとして運営したことがある
+    * 過去に Rails Girls イベントに参加したことがある
+    * 過去に Rails Girls more のようなフォローアップイベントに参加したことがある
+* 参加支援費振込のための銀行口座等の情報を Rails Girls Japan メンバーに開示できること
+* RubyKaigi 2022における各種ポリシーを遵守できること
+    * **特に現地参加を希望する場合、[RubyKaigi 2022のCOVID-19感染対策ポリシー](https://rubykaigi.org/2022/covid-19/)をよくご確認ください**<br>
+      ※募集開始時点でのCOVID-19感染対策ポリシーにおいて、ワクチンの接種を完了(fully vaccianted)していること、参加受付時に接種証明の提示が必要となっています
+    * **感染対策ポリシーは状況に応じて更新されることがあるため、メールや [RubyKaigi Twitterアカウント(@RubyKaigi)](https://twitter.com/rubykaigi)によるアナウンスをよく確認するようお願いします**
+
+#### その他
+* blogに掲載するためのRubyKaigi 2022に参加しての感想の提出をお願いしています。
+
+### 応募に関するスケジュール
+
+* **応募締切 : 2022/07/31 10:00**
+* **選考結果通知 : 2022/08/08 (予定)**
+
+ご応募お待ちしております。


### PR DESCRIPTION
RubyKaigi 2022 参加支援の応募に関する情報をblog記事として掲載しました。
過去の回を参考にまとめてみたのですが、不備などあればご指摘をお願いします。