### PR TITLE
use hotwired turbo attributes

### DIFF
--- a/_posts/2012-04-30-commenting.markdown
+++ b/_posts/2012-04-30-commenting.markdown
@@ -71,7 +71,7 @@ app/views/ideas/show.html.erb を開いて、
     <strong><%= comment.user_name %></strong>
     <br />
     <p><%= comment.body %></p>
-    <p><%= link_to 'Delete', comment_path(comment), method: :delete, data: { confirm: '削除してもよろしいですか？' } %></p>
+    <p><%= link_to 'Delete', comment_path(comment), data: { turbo_method: :delete, turbo_confirm: '削除してもよろしいですか？' } %></p>
   </div>
 <% end %>
 <%= render 'comments/form', comment: @comment %>

--- a/_posts/2013-01-20-design.markdown
+++ b/_posts/2013-01-20-design.markdown
@@ -97,8 +97,8 @@ idea のタイトルをクリックすると、idea の詳細画面を見るこ�
     <p><b>Description: </b><%= @idea.description %></p>
     <p>
       <%= link_to 'Edit', edit_idea_path(@idea) %> |
-      <%= link_to 'Destroy', @idea, data: { confirm: 'Are you sure?' }, method: :delete %> |
       <%= link_to 'Back', ideas_path %>
+      <%= button_to 'Destroy', idea_path(@idea), form: { data: { turbo_confirm: "Are you sure?" } }, method: :delete %>
     </p>
   </div>
 </div>


### PR DESCRIPTION
現在 https://railsgirls.jp ではRails 7系をインストールする前提になっていますが、
Rails 7系でデフォルトとなった [Turbo](https://turbo.hotwired.dev/) に対応していないコードがあります。

次の箇所で想定していない挙動をしているようなので、修正します。
- [5. あなたのアプリにコメント出来るようにしましょう](https://railsgirls.jp/commenting): "Delete" リンクをクリックしても反応しない
- [6. bootstrap を使ってモダンなデザインにしましょう](https://railsgirls.jp/design): "Destroy" リンクをクリックしても反応しない

※ なお、後者については `link_to` ではなく `button_to` を使うよう変更しています。
これは `link_to` のままだと ideas#show で `ActiveRecord::RecordNotFound (Couldn't find Idea with 'id'=x)` が発生するためです。 

---

ref: https://turbo.hotwired.dev/reference/attributes
