### PR TITLE
リンク切れ修正

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -61,7 +61,7 @@
           <span class="icon-bar"></span>
         </a>
 
-        <a class="brand" href="http://railsgirls-jp.github.com/">Rails Girls Guides</a>
+        <a class="brand" href="/">Rails Girls Guides</a>
 
         <div class="nav-collapse navbar-responsive-collapse collapse" style="height: 0px;">
           <ul class="nav">

--- a/_posts/2013-05-10-EYDeploy.markdown
+++ b/_posts/2013-05-10-EYDeploy.markdown
@@ -93,4 +93,4 @@ __コーチの方へ__: staging と production の違いについて、そして
 ### 追加の情報源
 
  * [ビデオチュートリアル(日本語)](http://www.engineyard.co.jp/jp/landing/tour)
- * [EngineYard の別のチュートリアル(英語)](https://support.cloud.engineyard.com/entries/20996751-Tutorial-How-to-Deploy-the-ToDo-Application-on-a-Trial-Account)
+ * [EngineYard の別のチュートリアル(英語)](https://support.cloud.engineyard.com/hc/en-us/articles/205407568-Tutorial-How-to-Deploy-the-ToDo-Application-on-a-Trial-Account)

--- a/_posts/2013-07-23-bundlerfordevelopment.markdown
+++ b/_posts/2013-07-23-bundlerfordevelopment.markdown
@@ -8,7 +8,7 @@ permalink: bundlerfordevelopment
 
 1. Fork Bundler
 
-    Go to the Bundler Github [https://github.com/bundler/bundler](https://github.com/bundler/bundler)
+    Go to the Bundler Github [https://github.com/rubygems/bundler](https://github.com/rubygems/bundler)
 
     Press the fork button.
 
@@ -30,7 +30,7 @@ permalink: bundlerfordevelopment
 
 4. Configure the remote
 
-    `$ git remote add upstream https://github.com/bundler/bundler.git`
+    `$ git remote add upstream https://github.com/rubygems/bundler.git`
 
     This connects your local repo to the upstream repo at Github.
 
@@ -39,7 +39,7 @@ permalink: bundlerfordevelopment
 
     `$ rake spec:deps`
 
-    What is rake? [http://rake.rubyforge.org/](http://rake.rubyforge.org/)
+    What is rake? [https://ruby.github.io/rake/](https://ruby.github.io/rake/)
 
 6. Run the Bundler test suite
 

--- a/_posts/2013-12-18-add-gravatar.markdown
+++ b/_posts/2013-12-18-add-gravatar.markdown
@@ -8,7 +8,7 @@ permalink: gravatar
 
 *Created by Catherine Jones*
 
-このガイドは、すでに [RailsGirls アプリ・チュートリアル](http://guides.railsgirls.com/app/) と [Deviseによる認証を追加してみよう](http://guides.railsgirls.com/devise/) でアプリを作った方を対象にしています。
+このガイドは、すでに [RailsGirls アプリ・チュートリアル](/app) と [Deviseによる認証を追加してみよう](/devise) でアプリを作った方を対象にしています。
 
 ### 重要
 

--- a/_posts/2014-01-30-anynines.markdown
+++ b/_posts/2014-01-30-anynines.markdown
@@ -14,7 +14,7 @@ __COACH__: Talk about the benefits of deploying to anynines vs utilising US data
 
 1. [Create an anynines account](http://anynines.com/).
 
-2. [Download and install the Command Line Interface](https://anynines.zendesk.com/entries/60241846-How-to-install-the-CLI-v6) to interact with anynines.
+2. [Download and install the Command Line Interface](https://anynines.zendesk.com/hc/en-us/community/posts/234540388-How-to-install-the-CLI-v6) to interact with anynines.
 
 3. Now select the anynines api endpoint as target and authenticate using your user credentials:
 

--- a/index.html
+++ b/index.html
@@ -6,18 +6,18 @@ title: 日本語版ガイド
   <h2>Rails Girls ガイド</h2>
   <p>Rails Girlsはより多くの女性がプログラミングに親しみ、アイデアを形にできる技術を身につける手助けをするコミュニティです。あなたの地域で、それぞれのRails Girlsを開催してください。あなた流の手引きで行ってもいいですし、ここのドキュメントを使ってRailsを勉強するだけでも構いません。もし、もっとRails Girlsに関わりたいと思ったら、<a href="http://groups.google.com/group/rails-girls-team">Rails Girls Teamメーリングリスト(英語)</a>にご参加ください。</p>
   <p class="hero-links">
-    <a href="http://railsgirls.com">Rails Girls Official site</a><br/>
-    <a href="http://guides.railsgirls.com/">Guides in English</a><br/>
-    <a href="http://railsgirls.jp/">Guides in Japanese</a><br/>
-    <a href="http://railspremierspas.humancoders.com/">Guides in French</a><br/>
-    <a href="http://rgcn.github.com">Guides in Chinese</a><br/>
-    <a href="http://rgua.github.com">Guides in Russian</a><br/>
-    <a href="http://guides.railsgirls.com/guides-ptbr/">Guides in Brazilian-Portuguese</a><br>
-    <a href="http://railsgirlslima.github.io/">Guides in Spanish</a><br/>
-    <a href="http://railsgirls.tw/">Guides in Traditional Chinese</a><br/>
-    <a href="http://railsgirlshh.github.io/">Guides in German</a><br/>
-    <a href="http://guides.railsgirls.co.il/">Guides in Hebrew</a><br/>
-    <a href="http://railsgirls.rug.lviv.ua/">Guides in Ukrainian</a><br/>
+    <a href="https://railsgirls.com">Rails Girls Official site</a><br/>
+    <a href="https://guides.railsgirls.com/">Guides in English</a><br/>
+    <a href="https://railsgirls.jp/">Guides in Japanese</a><br/>
+    <a href="https://railspremierspas.humancoders.com/">Guides in French</a><br/>
+    <a href="https://rgcn.github.io">Guides in Chinese</a><br/>
+    <a href="https://rgua.github.io">Guides in Russian</a><br/>
+    <a href="https://guides.railsgirls.com/guides-ptbr/">Guides in Brazilian-Portuguese</a><br>
+    <a href="https://railsgirlslima.github.io/">Guides in Spanish</a><br/>
+    <a href="https://railsgirls.tw/">Guides in Traditional Chinese</a><br/>
+    <a href="https://railsgirlshh.github.io/">Guides in German</a><br/>
+    <a href="https://guides.railsgirls.co.il/">Guides in Hebrew</a><br/>
+    <a href="https://railsgirls.rug.lviv.ua/">Guides in Ukrainian</a><br/>
   </p>
 </div>
 


### PR DESCRIPTION
リンク切れを修正しました

* bundlerはgithub pagesに移行済でした
* Rails GirlsガイドのURLは最後にバックスラッシュがあると404になってしまうようです
    * ここはドメインから指定する必要はないのでそこも対応しています
* EngineYardとanyninesは現在404になっていますが、WebArchiveで確認したら過去にリダイレクトが設定されていたページが見つかったので、そちらに更新しました
* 各言語のRailsGuideのリンク切れ修正
    * 移行先が見つからないものもあり
* スマホ表示時のRailsGirlsGuideのロゴをクリックすると404になっていたのの修正