### PR TITLE
railsgirls.comのリンクがhttpsではアクセス出来ないので修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ title: 日本語版ガイド
   <h2>Rails Girls ガイド</h2>
   <p>Rails Girlsはより多くの女性がプログラミングに親しみ、アイデアを形にできる技術を身につける手助けをするコミュニティです。あなたの地域で、それぞれのRails Girlsを開催してください。あなた流の手引きで行ってもいいですし、ここのドキュメントを使ってRailsを勉強するだけでも構いません。もし、もっとRails Girlsに関わりたいと思ったら、<a href="http://groups.google.com/group/rails-girls-team">Rails Girls Teamメーリングリスト(英語)</a>にご参加ください。</p>
   <p class="hero-links">
-    <a href="https://railsgirls.com">Rails Girls Official site</a><br/>
+    <a href="http://railsgirls.com">Rails Girls Official site</a><br/>
     <a href="https://guides.railsgirls.com/">Guides in English</a><br/>
     <a href="https://railsgirls.jp/">Guides in Japanese</a><br/>
     <a href="https://railspremierspas.humancoders.com/">Guides in French</a><br/>


### PR DESCRIPTION
トップページのrailsgirls.comへのリンクがhttpsになっていてアクセスできないため、とりあえずの対応としてhttpでアクセスするようにリンクを修正しました。