### PR TITLE
Rails Girls JapanのTwitterとInstagramリンクを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,8 @@ title: 日本語版ガイド
   </a>
 </div>
 
+Rails Girls Japanの<a href="https://twitter.com/RailsGirlsJapan">Twitter</a>や<a href="https://www.instagram.com/railsgirlsjapan/">Instagram</a>では、日本国内で開催するRails Girlsイベント情報などをお知らせしています！
+
 <h2>Rails Girls にようこそ!</h2>
 <ul class="home">
   <li>


### PR DESCRIPTION
![Rails-Girls-Japanese](https://user-images.githubusercontent.com/1575990/223130989-f0b6356b-a2e6-4172-bcf8-d66da11bd453.png)

思ったよりねじ込む余地がなく、やや強引な気もしますがRails Girls JapanのTwitterとInstagramアカウントへのリンクを追加してみました。
フッター部分のGlobalアカウントへのリンク下部あたりに付け足すのもアリかなという気持ちもありました。

最初に作った時点ではこれでバッチリ！という感じではあまりないつもりでしたので、ご意見いただけるとうれしいです。