### PR TITLE
Add `rake test` command to check HTML files by HTML Proofer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gem 'webrick'
 gem 'github-pages'
 
 gem 'jekyll-paginate'
+gem 'html-proofer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,15 @@ GEM
     html-pipeline (2.14.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
+    html-proofer (4.4.3)
+      addressable (~> 2.3)
+      mercenary (~> 0.3)
+      nokogiri (~> 1.13)
+      parallel (~> 1.10)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
+      zeitwerk (~> 2.5)
     http_parser.rb (0.8.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -206,11 +215,15 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
+    mini_portile2 (2.8.1)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.17.0)
+    nokogiri (1.14.0)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.14.0-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.0-x86_64-darwin)
@@ -220,10 +233,12 @@ GEM
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
+    parallel (1.22.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.7)
     racc (1.6.2)
+    rainbow (3.1.1)
     rake (13.0.6)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -255,16 +270,19 @@ GEM
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
     webrick (1.7.0)
+    yell (2.2.2)
     zeitwerk (2.6.6)
 
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  ruby
   x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
   github-pages
+  html-proofer
   jekyll-paginate
   rake
   webrick

--- a/Rakefile
+++ b/Rakefile
@@ -118,3 +118,35 @@ end
 
 #Load custom rake scripts
 Dir['_rake/*.rake'].each { |r| load r }
+
+# Check HTML files by HTMLProofer: https://github.com/gjtorikian/html-proofer
+require 'html-proofer'
+task :test do
+  options = {
+    checks: [
+      'Links',
+      'Images',
+      'Favicon',
+      'Scripts',
+      'OpenGraph',
+    ],
+    allow_hash_href:    false,
+    allow_missing_href: true,
+    disable_external:   true,
+    enforce_https:      false,
+
+    ignore_empty_alt:   true,
+    ignore_missing_alt: true,
+
+    # NOTE: Ignore file, URL, and response as follows
+    ignore_files: [
+      /2017(.*)\.html/,
+      /2018(.*)\.html/,
+      /2019(.*)\.html/,
+      /2021(.*)\.html/,
+      /2022(.*)\.html/,
+    ],
+  }
+
+  HTMLProofer.check_directory('_site', options).run
+end


### PR DESCRIPTION
リンク切れなどをチェックするテスト ([HTML Proofer](https://github.com/gjtorikian/html-proofer)) を追加しました! デフォルトの設定だと800ヶ所ほどエラー・警告があったため、一旦ゆるめの設定にしています。 cc/ @hsbt 

## 現在の設定（ゆるめ）
チェック対象: `checks: ['Links', 'Images', 'Favicon', 'Scripts', 'OpenGraph']`

```console
$ bundle exec rake test
Running 5 checks (Scripts, OpenGraph, Links, Images, Favicon) in ["_site"] on *.html files...

Checking 139 internal links
Checking internal link hashes in 2 files
Ran on 86 files!

HTML-Proofer finished successfully.
```

## デフォルトの設定  ([`disable_external: true`](https://github.com/gjtorikian/html-proofer#configuration) のみ追加。内部リンクのみテスト)
チェック対象: `checks: ['Links', 'Images', 'Favicon', 'Scripts', 'OpenGraph']`

```console
$  bundle exec rake test
Running 5 checks (Scripts, OpenGraph, Links, Images, Favicon) in ["_site"] on *.html files...

... (長いので省略)

* At _site/2019/12/25/start-accepting-rubykaigi2020-support-for-alumni/index.html:97:
  internally linking to /2017/09/23/rubykaigi2017-support-for-alumni/, which does not exist

* At _site/2021/09/01/start-accepting-rubykaigi-takeout-2021-support-for-alumni/index.html:97:
  internally linking to /2017/09/23/rubykaigi2017-support-for-alumni/, which does not exist

* At _site/2022/06/29/start-accepting-rubykaigi2022-support-for-alumni/index.html:97:
  internally linking to /2017/09/23/rubykaigi2017-support-for-alumni/, which does not exist

HTML-Proofer found 815 failures!
```