### PR TITLE
Bootstrapのバージョンを5.2.3に更新

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -93,8 +93,7 @@ rails server
 この1行前に次のタグを追記してください。
 
 {% highlight erb %}
-<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
 {% endhighlight %}
 
 そして、この部分、
@@ -113,21 +112,18 @@ rails server
 
 次に、ナビゲーションバーとフッターをレイアウトに追加してみましょう。同じファイルの`<body>`の直後に以下を追加してください。
 
-{% highlight html %}
-<nav class="navbar navbar-default navbar-fixed-top" role="navigation">
-  <div class="container">
-    <div class="navbar-header">
-      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
-      <a class="navbar-brand" href="/">The Idea app</a>
-    </div>
-    <div class="collapse navbar-collapse">
-      <ul class="nav navbar-nav">
-        <li class="active"><a href="/ideas">Ideas</a></li>
+{% highlight erb %}
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/">The idea app</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item">
+          <a class="nav-link <%= 'active' if current_page?(controller: 'ideas') %>" href="/ideas">Ideas</a>
+        </li>
       </ul>
     </div>
   </div>
@@ -136,24 +132,24 @@ rails server
 
 さらに、`</body>` の直前に以下を追加してください。
 
-{% highlight html %}
-<footer>
+{% highlight erb %}
+<footer class="mt-5 text-center">
   <div class="container">
-    Rails Girls 2022
+    Rails Girls <%= Time.now.year %>
   </div>
 </footer>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
 {% endhighlight %}
 
-ここで、ideasの表のスタイルも変更してみましょう。`app/assets/stylesheets/application.css` を開いて、コードの一番下に次のcssを追加しましょう。
+ここで、ideasの一覧のスタイルも変更してみましょう。`app/assets/stylesheets/application.css` を開いて、コードの一番下に次のcssを追加しましょう。
 
 
 {% highlight css %}
-body { padding-top: 100px; }
-footer { margin-top: 100px; }
-table, td, th { vertical-align: middle; border: none; }
-th { border-bottom: 1px solid #DDD; }
+#ideas > div {
+  border-top: 1px solid #c0c0c0;
+  margin-top: 30px;
+  padding-top: 30px;
+}
 {% endhighlight %}
 
 ファイルがきちんと保存されたことを確認して、何が変わったのかを見るためにブラウザを更新してみましょう。


### PR DESCRIPTION
これまでBootstrap3.3.7が利用されていましたが、現在最新が5系なので差し替えました。
差し替えにあたっては https://guides.railsgirls.com/html-and-css の表記を流用させていただきました。 https://github.com/railsgirls/railsgirls.github.io/blob/b0dfe70ed55c96cc5444b5980c996dad1555649f/_pages/html-and-css.md

スタイルの追加に関する表記は guides.railsgirls.com にはないのですが、
スタイルの追加をする体験は利用者にとって有用だろうと思い、
cssを変更する方針で維持しました。