### PR TITLE
Blogのlayoutが崩れていたため修正

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,7 +1,6 @@
 ---
+layout: default
 ---
-{% include header.html %}
-
 <article class="container">
   <div class="row">
 
@@ -37,5 +36,3 @@
 
   </div>
 </article>
-
-{% include footer.html %}

--- a/css/style.css
+++ b/css/style.css
@@ -398,7 +398,8 @@ i.icon-small-browser {
   display: block;
   border-bottom: solid 3px #EC644B;
   bottom: -3px;
-  width: 30%;
+  left: -1px;
+  width: 100%;
 }
 
 .page__body {
@@ -407,7 +408,7 @@ i.icon-small-browser {
 
 .page__link {
   margin-top: 3em;
-  background: rgba(247, 244, 237, .8);
+//  background: rgba(247, 244, 237, .8);
   padding: 0.8em;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -384,14 +384,15 @@ i.icon-small-browser {
 }
 
 .page__header .page__title{
-  border-bottom: solid 3px #BFBFBF;
   position: relative;
   padding: 0.4em;
   color: #444444;
   font-weight: 600;
   font-family: "YuGothic","Yu Gothic","Meiryo","ヒラギノ角ゴ","sans-serif";
+  border-bottom: solid 3px #EC644B;
 }
 
+/*
 .page__header .page__title::before {
   position: absolute;
   content: " ";
@@ -401,6 +402,7 @@ i.icon-small-browser {
   left: -1px;
   width: 100%;
 }
+*/
 
 .page__body {
   word-break: break-all;
@@ -408,7 +410,6 @@ i.icon-small-browser {
 
 .page__link {
   margin-top: 3em;
-//  background: rgba(247, 244, 237, .8);
   padding: 0.8em;
 }
 


### PR DESCRIPTION
* Blogで使用しているlayout: post.htmlが default.html を継承していなかったため、 スタイルが崩れていたので、default.htmlを継承するように変更

* styleの表示が気になった箇所を修正
  * article titleの下線が右に1pxずれていた
  * blogの前後ページへのリンク表示エリアのbgcolorがfooterと異なる色で違和感があったので、 bgcolor指定はしないようにした


![image](https://user-images.githubusercontent.com/458273/230408599-959481f3-c959-4d74-894c-297b1792c725.png)

![image](https://user-images.githubusercontent.com/458273/230409254-164110ba-c88d-4697-9d22-73046251757f.png)
