### PR TITLE
Nagasaki 1stイベントページの各種募集フォームをクローズ

### DIFF
--- a/events/nagasaki.html
+++ b/events/nagasaki.html
@@ -16,12 +16,14 @@ title: "Nagasaki, 14th & 15th April 2023"
         Ruby on Rails のすてきな世界を私達と一緒に体験しましょう！
       </p>
 
+      <!--
       <p><strong>Rails Girls Nagasaki 1st の参加者を募集します。<br />
           2日間のワークショップとなります。
           無料のワークショップですので、お気軽にご参加ください。</strong></p>
+      -->
 <!--          <p><strong>2月下旬より参加者の募集を開始いたします。今しばらくお待ち下さい。</strong></p>-->
 
-
+      <!--
       <p>
         <strong>
           応募を開始しました！！！<br/>
@@ -29,13 +31,14 @@ title: "Nagasaki, 14th & 15th April 2023"
           応募が多い場合は抽選となります。ご了承ください。
         </strong>
       </p>
+       -->
 
-<!--          <p>-->
-<!--            <strong>参加お申し込みは締め切らせていただきました。<br/>-->
-<!--              ご応募いただいた皆様ありがとうございました。<br/>-->
-<!--            </strong>-->
-<!--            <br />-->
-<!--          </p>-->
+       <p>
+        <strong>参加お申し込みは締め切らせていただきました。<br/>
+          ご応募いただいた皆様ありがとうございました。<br/>
+        </strong>
+        <br />
+      </p>
 
       <div id="share">
         <div>
@@ -205,10 +208,12 @@ title: "Nagasaki, 14th & 15th April 2023"
       <!-- Feel free to group the sponsors ascommi you wish. E.g media, friends, premium sponsors etc. You know best the situation in your city! Pictures should be either 100 x 100px or 250 x 90px -->
 
       <h3>パートナー</h3>
+      <!--
       <p>
         ご支援いただけるパートナーを募集しております。<br>
         <a href="https://forms.gle/pMD9XjASVujgDtyt5" target="_blank">こちらのフォーム</a>からお問合せください。
       </p>
+      -->
 
       <!-- <p>多数のご支援のお申し出をいただき、ありがとうございました！<br>
         Rails Girls Nagasaki は以下のすばらしいパートナーとの共同開催です。


### PR DESCRIPTION
Nagasaki 1stのガールズ募集期間が終了したので、既にクローズしていたスポンサー申し込みフォームと合わせてステータスを更新しました。
内容としては https://github.com/railsgirls/railsgirls.org/pull/2173 と同等のものになっているかと思います。(合わせてご確認いただけるとうれしいです:pray:)

railsgirls.orgの方にリンクを直す、でも良さそうと思ったのですが、ちょっとややこしいかなと思いまして、イベント終了してpast eventsに移すタイミングまでを目途に並行管理にしようかなと思っていました。