### PR TITLE
Revert "イベントページのrailsgirls.com -> railsgirls.orgへ変更"

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -15,11 +15,11 @@ title: "Rails Girls Events"
     <h3>Rails Girls Gathering Japan 2022<small>2022/12/03</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/tokyo-2022-07-30.html" class="span4 event" style="background: url(/images/events/tokyo-14th-banner.png) 0px -10px / 100% no-repeat;">
+  <a href="http://railsgirls.com/tokyo-2022-07-30.html" class="span4 event" style="background: url(/images/events/tokyo-14th-banner.png) 0px -10px / 100% no-repeat;">
     <h3>Tokyo, Japan<small>July 29th & 30th, 2022</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/kagoshima-2022.html" class="span4 event" style="background: url(/images/events/kagoshima-2022.png) 90px 5px / 40% no-repeat;">
+  <a href="http://railsgirls.com/kagoshima-2022.html" class="span4 event" style="background: url(/images/events/kagoshima-2022.png) 90px 5px / 40% no-repeat;">
     <h3>Kagoshima<small>24th & 25th June 2022</small></h3>
   </a>
 
@@ -27,275 +27,275 @@ title: "Rails Girls Events"
     <h3>Rails Girls Gathering Japan 2021<small>2021/08/28</small></h3>
   </a>
 
-  <a href="https://qiita.com/advent-calendar/2020/railsgirlsjapan" class="span4 event" style="background:url(https://railsgirls.org/images/railsgirls-sq.png) 0px -70px / 100% no-repeat;">
+  <a href="https://qiita.com/advent-calendar/2020/railsgirlsjapan" class="span4 event" style="background:url(http://railsgirls.com/images/railsgirls-sq.png) 0px -70px / 100% no-repeat;">
     <h3>Advent Calendar 2020<small>2020/12/01-25</small></h3>
   </a>
 
-  <a href="https://railsgirls-japan.doorkeeper.jp/events/113760" class="span4 event" style="background:url(https://railsgirls.org/images/railsgirls-sq.png) 0px -70px / 100% no-repeat;">
+  <a href="https://railsgirls-japan.doorkeeper.jp/events/113760" class="span4 event" style="background:url(http://railsgirls.com/images/railsgirls-sq.png) 0px -70px / 100% no-repeat;">
     <h3>Rails Girls Gathering Japan<small>2020/12/12</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/tokyo-2020-02-15.html" class="span4 event" style="background: url(https://railsgirls.org/images/rg-tokyo-2020-02-15.png) 0px -70px / 100% no-repeat;">
+  <a href="http://railsgirls.com/tokyo-2020-02-15.html" class="span4 event" style="background: url(http://railsgirls.com/images/rg-tokyo-2020-02-15.png) 0px -70px / 100% no-repeat;">
     <h3>Tokyo<small>14-15 February 2020</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/ehime" class="span4 event" style="background: url(https://railsgirls.org/images/ehime/railsgirls-logo.png) 0px -156px / 100% no-repeat;">
+  <a href="http://railsgirls.com/ehime" class="span4 event" style="background: url(http://railsgirls.com/images/ehime/railsgirls-logo.png) 0px -156px / 100% no-repeat;">
     <h3>Ehime<small>07-08 February 2020</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/nagoya" class="span4 event" style="background: url(https://railsgirls.org/images/rg-nagoya-5th.png) 0px -70px / 100% no-repeat;">
+  <a href="http://railsgirls.com/nagoya" class="span4 event" style="background: url(http://railsgirls.com/images/rg-nagoya-5th.png) 0px -70px / 100% no-repeat;">
     <h3>Nagoya<small>31 January - 01 February 2020</small></h3>
   </a>
 
-  <a href="https://qiita.com/advent-calendar/2019/railsgirlsjapan" class="span4 event" style="background:url(https://railsgirls.org/images/railsgirls-sq.png) 0px -70px no-repeat;">
+  <a href="https://qiita.com/advent-calendar/2019/railsgirlsjapan" class="span4 event" style="background:url(http://railsgirls.com/images/railsgirls-sq.png) 0px -70px no-repeat;">
     <h3>AdventCalendar 2019<small>2019/12/01-25</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/kyoto201911" class="span4 event" style="background: url(https://railsgirls.org/images/kyoto/10th_icon.png) center 5px / 120px no-repeat;">
+  <a href="http://railsgirls.com/kyoto201911" class="span4 event" style="background: url(http://railsgirls.com/images/kyoto/10th_icon.png) center 5px / 120px no-repeat;">
     <h3>Kyoto<small>2019/11/22-23</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/fukuoka" class="span4 event" style="background: url(https://railsgirls.org/images/fukuoka/fukuoka2019-logo.jpg) center 5px / 120px no-repeat;">
+  <a href="http://railsgirls.com/fukuoka" class="span4 event" style="background: url(http://railsgirls.com/images/fukuoka/fukuoka2019-logo.jpg) center 5px / 120px no-repeat;">
     <h3>Fukuoka<small>2019/11/01-02</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/okinawa-2nd" class="span4 event" style="background: url(https://railsgirls.org/images/okinawa/logo.jpg) 90px 5px / 40% no-repeat;">
+  <a href="http://railsgirls.com/okinawa-2nd" class="span4 event" style="background: url(http://railsgirls.com/images/okinawa/logo.jpg) 90px 5px / 40% no-repeat;">
     <h3>Okinawa<small>2019/10/04-05</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/tokyo-2019-08-03.html" class="span4 event" style="background: url(https://railsgirls.org/images/rg-tokyo-2019-08-02.png) 90px 5px / 40% no-repeat;">
+  <a href="http://railsgirls.com/tokyo-2019-08-03.html" class="span4 event" style="background: url(http://railsgirls.com/images/rg-tokyo-2019-08-02.png) 90px 5px / 40% no-repeat;">
     <h3>Tokyo<small>2019/08/02-03</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/sendai" class="span4 event" style="background: url(https://railsgirls.org/images/rg-sendai-2019-07-20.png) 90px 5px / 40% no-repeat;">
+  <a href="http://railsgirls.com/sendai" class="span4 event" style="background: url(http://railsgirls.com/images/rg-sendai-2019-07-20.png) 90px 5px / 40% no-repeat;">
     <h3>Sendai<small>2019/07/19-20</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/osaka" class="span4 event" style="background: url(https://railsgirls.org/images/osaka/rg-osaka6th.png) 90px 5px / 40% no-repeat;">
+  <a href="http://railsgirls.com/osaka" class="span4 event" style="background: url(http://railsgirls.com/images/osaka/rg-osaka6th.png) 90px 5px / 40% no-repeat;">
     <h3>Osaka<small>2019/06/21-22</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/ehime-2019-06-14" class="span4 event" style="background: url(https://railsgirls.org/images/ehime/railsgirls-logo-1st.png) 0px -70px / 100% no-repeat;">
+  <a href="http://railsgirls.com/ehime-2019-06-14" class="span4 event" style="background: url(http://railsgirls.com/images/ehime/railsgirls-logo-1st.png) 0px -70px / 100% no-repeat;">
     <h3>Ehime<small>2019/06/14-15</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/nagano" class="span4 event" style="background: url(https://railsgirls.org/images/nagano/rg-nagano-1st.png) center 0 / 40% no-repeat;">
+  <a href="http://railsgirls.com/nagano" class="span4 event" style="background: url(http://railsgirls.com/images/nagano/rg-nagano-1st.png) center 0 / 40% no-repeat;">
     <h3>Nagano<small>2019/05/24-25</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/tokyo-2019-02-22.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-tokyo-2019-02-22.png) 90px 5px / 40% no-repeat;">
+  <a href="http://railsgirls.com/tokyo-2019-02-22.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-tokyo-2019-02-22.png) 90px 5px / 40% no-repeat;">
     <h3>Tokyo<small>2019/02/22-23</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/kobe201901.html" class="span4 event" style="background:url(https://railsgirls.org/images/kobe/rg-kobe0-logo.png) 90px 5px / 40% no-repeat;">
+  <a href="http://railsgirls.com/kobe201901.html" class="span4 event" style="background:url(http://railsgirls.com/images/kobe/rg-kobe0-logo.png) 90px 5px / 40% no-repeat;">
     <h3>Kobe<small>2019/01/26-27</small></h3>
   </a>
 
-  <a href="https://qiita.com/advent-calendar/2018/railsgirlsjapan" class="span4 event" style="background:url(https://railsgirls.org/images/railsgirls-sq.png) 0px -70px no-repeat;">
+  <a href="https://qiita.com/advent-calendar/2018/railsgirlsjapan" class="span4 event" style="background:url(http://railsgirls.com/images/railsgirls-sq.png) 0px -70px no-repeat;">
     <h3>AdventCalendar 2018<small>2018/12/01-25</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/kyoto201812.html" class="span4 event" style="background:url(https://railsgirls.org/images/kyoto/railsgirlskyoto9th.png) 0px -25px / 100% no-repeat;">
+  <a href="http://railsgirls.com/kyoto201812.html" class="span4 event" style="background:url(http://railsgirls.com/images/kyoto/railsgirlskyoto9th.png) 0px -25px / 100% no-repeat;">
     <h3>Kyoto<small>2018/12/07-08</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/okinawa.html" class="span4 event" style="background:url(https://railsgirls.org/images/okinawa/railsgirls.jpg) 0px -83px / 100% no-repeat;">
+  <a href="http://railsgirls.com/okinawa.html" class="span4 event" style="background:url(http://railsgirls.com/images/okinawa/railsgirls.jpg) 0px -83px / 100% no-repeat;">
     <h3>Okinawa<small>2018/11/9-10</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/matsue.html" class="span4 event" style="background: url(https://railsgirls.org/images/rg-matsue.png) 0px -70px / 100% no-repeat;">
+  <a href="http://railsgirls.com/matsue.html" class="span4 event" style="background: url(http://railsgirls.com/images/rg-matsue.png) 0px -70px / 100% no-repeat;">
     <div>
       <h3>Matsue, Japan<small>10 November 2018</small></h3>
     </div>
   </a>
 
-  <a href="https://railsgirls.org/sendai-2018-11-03.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-sendai-2018-11-03.png) 60px -75px / 70% no-repeat;">
+  <a href="http://railsgirls.com/sendai-2018-11-03.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-sendai-2018-11-03.png) 60px -75px / 70% no-repeat;">
     <h3>Sendai<small>2018/11/02-03</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/tokyo-2018-10-13.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-tokyo-2018-10-13.png) 0px -50px / 100% no-repeat;">
+  <a href="http://railsgirls.com/tokyo-2018-10-13.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-tokyo-2018-10-13.png) 0px -50px / 100% no-repeat;">
     <h3>Tokyo<small>2018/10/12-13</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/osaka-5th.html" class="span4 event" style="background:url(https://railsgirls.org/images/osaka/rg-osaka5th.png) 0px 0px / 100% no-repeat;">
+  <a href="http://railsgirls.com/osaka-5th.html" class="span4 event" style="background:url(http://railsgirls.com/images/osaka/rg-osaka5th.png) 0px 0px / 100% no-repeat;">
     <h3>Osaka<small>2018/6/16-17</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/tokyo-2018-05-18.html" class="span4 event" style="background: url(https://railsgirls.org/images/rg-tokyo-2018-05-18.png) 0px -70px / 100% no-repeat;">
+  <a href="http://railsgirls.com/tokyo-2018-05-18.html" class="span4 event" style="background: url(http://railsgirls.com/images/rg-tokyo-2018-05-18.png) 0px -70px / 100% no-repeat;">
     <div>
       <h3>Tokyo, Japan<small>18-19 May 2018</small></h3>
     </div>
   </a>
 
-  <a href="https://railsgirls.org/okayama2018.html" class="span4 event" style="background: url(https://railsgirls.org/images/okayama/3rd/rg-okayama-3rd.png) 85px 0px / 45% no-repeat;">
+  <a href="http://railsgirls.com/okayama2018.html" class="span4 event" style="background: url(http://railsgirls.com/images/okayama/3rd/rg-okayama-3rd.png) 85px 0px / 45% no-repeat;">
     <div>
       <h3>Okayama, Japan<small>17 - 18 February 2018</small></h3>
     </div>
   </a>
 
-  <a href="https://railsgirls.org/nagoya_4th.html" class="span4 event" style="background: url(https://railsgirls.org/images/rg-nagoya-4th.png) 0px -70px / 100% no-repeat;">
+  <a href="http://railsgirls.com/nagoya_4th.html" class="span4 event" style="background: url(http://railsgirls.com/images/rg-nagoya-4th.png) 0px -70px / 100% no-repeat;">
     <div>
       <h3>Nagoya, Japan<small>26-27 January 2018</small></h3>
     </div>
   </a>
 
-  <a href="https://qiita.com/advent-calendar/2017/railsgirlsjapan" class="span4 event" style="background:url(https://railsgirls.org/images/railsgirls-sq.png) 0px -70px no-repeat;">
+  <a href="https://qiita.com/advent-calendar/2017/railsgirlsjapan" class="span4 event" style="background:url(http://railsgirls.com/images/railsgirls-sq.png) 0px -70px no-repeat;">
     <h3>AdventCalendar 2017<small>2017/12/01-25</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/kyoto201711.html" class="span4 event" style="background:url(https://railsgirls.org/images/kyoto/railsgirlskyoto8th.jpg) 0 -65px / 100% no-repeat;">
+  <a href="http://railsgirls.com/kyoto201711.html" class="span4 event" style="background:url(http://railsgirls.com/images/kyoto/railsgirlskyoto8th.jpg) 0 -65px / 100% no-repeat;">
     <h3>Kyoto<small>2017/11/24-25</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/tokyo-2017-10-07.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-tokyo-2017-10-07.png) 90px 5px / 45% no-repeat;">
+  <a href="http://railsgirls.com/tokyo-2017-10-07.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-tokyo-2017-10-07.png) 90px 5px / 45% no-repeat;">
     <h3>Tokyo<small>2017/10/06-07</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/kobe201709" class="span4 event" style="background:url(https://railsgirls.org/images/kobe/rg-kobe0-logo.png) 90px 5px / 45% no-repeat;">
+  <a href="http://railsgirls.com/kobe201709" class="span4 event" style="background:url(http://railsgirls.com/images/kobe/rg-kobe0-logo.png) 90px 5px / 45% no-repeat;">
     <h3>Kobe<small>2017/09/08-09</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/takasaki" class="span4 event" style="background:url(https://railsgirls.org/images/railsgirls-sq.png) 0px -70px / 100% no-repeat;">
+  <a href="http://railsgirls.com/takasaki" class="span4 event" style="background:url(http://railsgirls.com/images/railsgirls-sq.png) 0px -70px / 100% no-repeat;">
     <h3>Takasaki<small>2017/06/16-17</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/tokyo-2017-03-25.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-tokyo-2017-03-25.png) 0px 0px / 100% no-repeat;">
+  <a href="http://railsgirls.com/tokyo-2017-03-25.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-tokyo-2017-03-25.png) 0px 0px / 100% no-repeat;">
     <h3>Tokyo<small>2017/03/24-25</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/kitakyushu.html" class="span4 event" style="background:url(https://railsgirls.org/images/kitakyushu/rg-kitakyushu-event.png) 0px 0px / 100% no-repeat;">
+  <a href="http://railsgirls.com/kitakyushu.html" class="span4 event" style="background:url(http://railsgirls.com/images/kitakyushu/rg-kitakyushu-event.png) 0px 0px / 100% no-repeat;">
     <h3>Kitakyushu<small>2017/03/10-11</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/kyoto201703.html" class="span4 event" style="background:url(https://railsgirls.org/images/kyoto/railsgirlskyoto7th.png) 0 -65px / 100% no-repeat;">
+  <a href="http://railsgirls.com/kyoto201703.html" class="span4 event" style="background:url(http://railsgirls.com/images/kyoto/railsgirlskyoto7th.png) 0 -65px / 100% no-repeat;">
     <h3>Kyoto<small>2017/03/10-11</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/matsue-3rd.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-matsue.png) 50px -25px / 60% no-repeat;">
+  <a href="http://railsgirls.com/matsue-3rd.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-matsue.png) 50px -25px / 60% no-repeat;">
     <h3>Matsue<small>2017/03/03-04</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/okayama2017.html" class="span4 event" style="background:url(https://railsgirls.org/images/okayama/2nd/logo.jpg) 0px 0px / 100% no-repeat;">
+  <a href="http://railsgirls.com/okayama2017.html" class="span4 event" style="background:url(http://railsgirls.com/images/okayama/2nd/logo.jpg) 0px 0px / 100% no-repeat;">
     <h3>Okayama<small>2017/02/25-26</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/osaka-4th.html" class="span4 event" style="background:url(https://railsgirls.org/images/osaka/rg-osaka4th-event.png) 0px 0px / 100% no-repeat;">
+  <a href="http://railsgirls.com/osaka-4th.html" class="span4 event" style="background:url(http://railsgirls.com/images/osaka/rg-osaka4th-event.png) 0px 0px / 100% no-repeat;">
     <h3>Osaka<small>2017/02/17-18</small></h3>
   </a>
 
-  <a href="https://qiita.com/advent-calendar/2016/railsgirlsjapan" class="span4 event" style="background:url(https://railsgirls.org/images/railsgirls-sq.png) 0px -70px no-repeat;">
+  <a href="https://qiita.com/advent-calendar/2016/railsgirlsjapan" class="span4 event" style="background:url(http://railsgirls.com/images/railsgirls-sq.png) 0px -70px no-repeat;">
     <h3>AdventCalendar 2016<small>2016/12/01-25</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/kyoto201611" class="span4 event" style="background:url(https://railsgirls.org/images/kyoto/logo1-6th.png) 11px -59px no-repeat;">
+  <a href="http://railsgirls.com/kyoto201611" class="span4 event" style="background:url(http://railsgirls.com/images/kyoto/logo1-6th.png) 11px -59px no-repeat;">
     <h3>Kyoto<small>2016/11/25-26</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/kobe201611" class="span4 event" style="background:url(https://railsgirls.org/images/kobe/rg-kobe2-logo-a.png) 30px -80px / 80% no-repeat;">
+  <a href="http://railsgirls.com/kobe201611" class="span4 event" style="background:url(http://railsgirls.com/images/kobe/rg-kobe2-logo-a.png) 30px -80px / 80% no-repeat;">
     <h3>Kobe<small>2016/11/4-5</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/nagoya_3rd.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-nagoya-3rd.png) 30px -300px no-repeat;">
+  <a href="http://railsgirls.com/nagoya_3rd.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-nagoya-3rd.png) 30px -300px no-repeat;">
     <h3>Nagoya<small>2016/10/28-29</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/kyoto201609" class="span4 event" style="background:url(https://railsgirls.org/images/kyoto/rails5th_300px.png) 0px -46px / 100% no-repeat;">
+  <a href="http://railsgirls.com/kyoto201609" class="span4 event" style="background:url(http://railsgirls.com/images/kyoto/rails5th_300px.png) 0px -46px / 100% no-repeat;">
     <h3>Kyoto<small>2016/09/11</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/tokyo-2016-07-23" class="span4 event" style="background:url(https://railsgirls.org/images/rg-tokyo-2016-07-23.png) 0px 0px / 100% no-repeat;">
+  <a href="http://railsgirls.com/tokyo-2016-07-23" class="span4 event" style="background:url(http://railsgirls.com/images/rg-tokyo-2016-07-23.png) 0px 0px / 100% no-repeat;">
     <h3>Tokyo<small>2016/07/22-23</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/osaka-3rd.html" class="span4 event" style="background:url(https://railsgirls.org/images/osaka/rg-osaka-3rd.png) 0px 0px / 100% no-repeat;">
+  <a href="http://railsgirls.com/osaka-3rd.html" class="span4 event" style="background:url(http://railsgirls.com/images/osaka/rg-osaka-3rd.png) 0px 0px / 100% no-repeat;">
     <h3>Osaka<small>2016/06/18-19</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/okayama2015" class="span4 event" style="background:url(https://railsgirls.org/images/okayama/rg-okayama.png) 50px -40px no-repeat; background-size: 200px">
+  <a href="http://railsgirls.com/okayama2015" class="span4 event" style="background:url(http://railsgirls.com/images/okayama/rg-okayama.png) 50px -40px no-repeat; background-size: 200px">
     <h3>Okayama<small>2015/12/18-19</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/kyoto201511" class="span4 event" style="background:url(https://railsgirls.org/images/kyoto/logo1-4th.jpg) 0px -134px no-repeat; background-size: 300px">
+  <a href="http://railsgirls.com/kyoto201511" class="span4 event" style="background:url(http://railsgirls.com/images/kyoto/logo1-4th.jpg) 0px -134px no-repeat; background-size: 300px">
     <h3>Kyoto<small>2015/11/20-21</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/matsue-2nd.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-matsue-2015-11-13.png) 40px 0px / 90% no-repeat;">
+  <a href="http://railsgirls.com/matsue-2nd.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-matsue-2015-11-13.png) 40px 0px / 90% no-repeat;">
     <h3>Matsue<small>2015/11/13-14</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/kobe201509.html" class="span4 event" style="background:url(https://railsgirls.org/images/kobe/rg-kobe1-logo2.jpg) 90px 5px / 40% no-repeat;">
+  <a href="http://railsgirls.com/kobe201509.html" class="span4 event" style="background:url(http://railsgirls.com/images/kobe/rg-kobe1-logo2.jpg) 90px 5px / 40% no-repeat;">
     <h3>Kobe<small>2015/09/11-12</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/tokyo-2015-09-12.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-tokyo.png) 90px -80px / 50% no-repeat;">
+  <a href="http://railsgirls.com/tokyo-2015-09-12.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-tokyo.png) 90px -80px / 50% no-repeat;">
     <h3>Tokyo<small>2015/09/11-12</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/toyama-2015-8-25.html" class="span4 event" style="background:url(https://railsgirls.org/images/logo_toyama_first.png) 90px 5px / 40% no-repeat;">
+  <a href="http://railsgirls.com/toyama-2015-8-25.html" class="span4 event" style="background:url(http://railsgirls.com/images/logo_toyama_first.png) 90px 5px / 40% no-repeat;">
     <h3>Toyama<small>2015/08/25</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/fukuoka-2015.html" class="span4 event" style="background:url(https://railsgirls.org/images/fukuoka/railsgirls.png) 10px -50px / 95% no-repeat;">
+  <a href="http://railsgirls.com/fukuoka-2015.html" class="span4 event" style="background:url(http://railsgirls.com/images/fukuoka/railsgirls.png) 10px -50px / 95% no-repeat;">
     <h3>Fukuoka<small>2015/07/24-25</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/osaka-2nd.html" class="span4 event" style="background: url(https://railsgirls.org/images/osaka/rg-osaka-2nd.jpg) 0px -100px / 95% no-repeat;">
+  <a href="http://railsgirls.com//osaka-2nd.html" class="span4 event" style="background: url(http://railsgirls.com/images/osaka/rg-osaka-2nd.jpg) 0px -100px / 95% no-repeat;">
     <h3>Osaka<small>2015/06/19-20</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/kyoto201504" class="span4 event" style="background:url(https://railsgirls.org/images/kyoto/logo1-3rd-thumb.jpg) 25px -30px no-repeat;">
+  <a href="http://railsgirls.com/kyoto201504" class="span4 event" style="background:url(http://railsgirls.com/images/kyoto/logo1-3rd-thumb.jpg) 25px -30px no-repeat;">
     <h3>Kyoto<small>2015/04/24-25</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/shiojiri.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-shiojiri.jpg) 30px -50px / 80% no-repeat;">
+  <a href="http://railsgirls.com/shiojiri.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-shiojiri.jpg) 30px -50px / 80% no-repeat;">
     <h3>Shiojiri <small>2015/03/07</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/kyoto2014" class="span4 event" style="background:url(https://railsgirls.org/images/kyoto/main-image-thumb-2nd.jpg) 0px -168px no-repeat;">
+  <a href="http://railsgirls.com/kyoto2014" class="span4 event" style="background:url(http://railsgirls.com/images/kyoto/main-image-thumb-2nd.jpg) 0px -168px no-repeat;">
     <h3>Kyoto<small>2014/11/28-29</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/nagoya_2nd.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-nagoya-2nd.png) 0px -65px no-repeat;">
+  <a href="http://railsgirls.com/nagoya_2nd.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-nagoya-2nd.png) 0px -65px no-repeat;">
     <h3>Nagoya<small>2014/10/17-18</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/tokyo-2014-09-21.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-tokyo-2014-09-21.jpg) 0px -40px no-repeat;">
+  <a href="http://railsgirls.com/tokyo-2014-09-21.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-tokyo-2014-09-21.jpg) 0px -40px no-repeat;">
     <h3>Tokyo <small>2014/09/21</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/osaka-1st.html" class="span4 event" style="background: url(https://railsgirls.org/images/osaka/rg-osaka-1st.jpg) -35px -110px no-repeat;">
+  <a href="http://railsgirls.com/osaka-1st.html" class="span4 event" style="background: url(http://railsgirls.com/images/osaka/rg-osaka-1st.jpg) -35px -110px no-repeat;">
     <h3>Osaka<small>2014/06/06-07</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/nara.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-nara.png) -60px -145px no-repeat;">
+  <a href="http://railsgirls.com/nara.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-nara.png) -60px -145px no-repeat;">
     <h3>Nara<small>2014/03/14-15</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/nagoya_1st" class="span4 event" style="background:url(https://railsgirls.org/images/rg-nagoya-1st.png) 0px -65px no-repeat;">
+  <a href="http://railsgirls.com/nagoya_1st" class="span4 event" style="background:url(http://railsgirls.com/images/rg-nagoya-1st.png) 0px -65px no-repeat;">
     <h3>Nagoya<small>2014/03/07-08</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/matsue-1st.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-matsue-2013-11-22.png) 0px -145px no-repeat;">
+  <a href="http://railsgirls.com/matsue-1st.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-matsue-2013-11-22.png) 0px -145px no-repeat;">
     <h3>Matsue <small>2013/11/22-23</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/tokyo-2013-10-18.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-tokyo-2013-10-18.jpg) 0px -40px no-repeat;">
+  <a href="http://railsgirls.com/tokyo-2013-10-18.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-tokyo-2013-10-18.jpg) 0px -40px no-repeat;">
     <h3>Tokyo <small>2013/10/18-19</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/sapporo.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-sapporo.png) 0px -40px no-repeat;">
+  <a href="http://railsgirls.com/sapporo.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-sapporo.png) 0px -40px no-repeat;">
     <h3>Sapporo <small>2013/08/09-10</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/tokyo-2013-03-01.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-tokyo-2013-03-01.png) 0px -40px no-repeat;">
+  <a href="http://railsgirls.com/tokyo-2013-03-01.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-tokyo-2013-03-01.png) 0px -40px no-repeat;">
     <h3>Tokyo <small>2013/03/01-02</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/kyoto2012" class="span4 event" style="background:url(https://railsgirls.org/images/rg-kyoto.png) 0px -40px no-repeat;">
+  <a href="http://railsgirls.com/kyoto2012" class="span4 event" style="background:url(http://railsgirls.com/images/rg-kyoto.png) 0px -40px no-repeat;">
     <h3>Kyoto <small>2012/12/14-15</small></h3>
   </a>
 
-  <a href="https://railsgirls.org/tokyo-2012-09-07.html" class="span4 event" style="background:url(https://railsgirls.org/images/rg-tokyo-2012-09-07.png) 0px -40px no-repeat;">
+  <a href="http://railsgirls.com/tokyo-2012-09-07.html" class="span4 event" style="background:url(http://railsgirls.com/images/rg-tokyo-2012-09-07.png) 0px -40px no-repeat;">
     <h3>Tokyo <small>2012/09/07-08</small></h3>
   </a>
 


### PR DESCRIPTION
Reverts railsgirls-jp/railsgirls-jp.github.io#644

なんやかんやあって、railsgirls.com がhttps対応もしたようなので、
railsgirls.org のPRのrevertかけます。

柴田さん、早急に railsgirls.org対応して頂いて、ありがとうございました！