### PR TITLE
共通で挿入されるメッセージ部分のCSSを追加

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -624,3 +624,38 @@ a:hover .guide-icon,
 .os-specific.big .picker-options a:hover {
   border-color: currentcolor;
 }
+
+[class*=-notice] {
+  margin-bottom: 20px;
+  padding: 10px 15px;
+  font-size: 120%;
+  border-radius: 10px;
+}
+[class*=-notice] :last-child {
+  margin-bottom: 0;
+}
+
+.guide-notice {
+  background-color: #FEF8EA;
+}
+.help-notice {
+  background-color: #FEF8EA;
+}
+.help-notice:before {
+  content: "ℹ️";
+  margin-right: 10px;
+}
+.coach-notice {
+  border: 2px solid #8102BB;
+}
+.coach-notice > div {
+  cursor: help;
+}
+.warning-notice {
+  border: 2px solid var(--highlight);
+}
+.warning-notice:before {
+  content: "Warning";
+  display: block;
+  font-weight: bold;
+}


### PR DESCRIPTION
## issue
- #663 
### 概要
以下の2箇所にCSSが反映されるようにした
<img width="1123" alt="Monosnap Rails Girls - Japanese 2023-05-04 11-12-41" src="https://user-images.githubusercontent.com/76797372/236096319-d7092c3d-a21d-4c5f-939b-150a10914ad2.png">
