### PR TITLE
Carrierwave ~> CarrierWave

### DIFF
--- a/_pages/thumbnails.md
+++ b/_pages/thumbnails.md
@@ -4,7 +4,7 @@ title: アイデア一覧を表示したときにサムネイル表示してみ�
 permalink: thumbnails
 ---
 
-# Carrierwave を使ってサムネイルを作ってみよう
+# CarrierWave を使ってサムネイルを作ってみよう
 
 *Created by Miha Filej, [@mfilej](https://twitter.com/mfilej), Translated by Hiroshi SHIBATA*
 

--- a/index.html
+++ b/index.html
@@ -143,9 +143,9 @@ Rails Girls Japanの<a href="https://twitter.com/RailsGirlsJapan">Twitter</a>や
   <li>
     <a href="thumbnails">
       <span class="guide-icon" data-icon="13"></span>
-      <h3>Carrierwave を使って画像をリサイズしよう</h3>
+      <h3>CarrierWave を使って画像をリサイズしよう</h3>
     </a>
-    <p>Carrierwave を使って画像をリサイズする方法を紹介します</p>
+    <p>CarrierWave を使って画像をリサイズする方法を紹介します</p>
   </li>
 
   <li>


### PR DESCRIPTION
現在は Carrier**W**ave の綴りが正しそうなので変更しました。from https://github.com/railsgirls/guides.railsgirls.com/pull/523