### PR TITLE
Fix file path app/views/ideas/index.html.erb

### DIFF
--- a/_pages/html-and-css.md
+++ b/_pages/html-and-css.md
@@ -17,7 +17,7 @@ permalink: html-and-css
 
 HTML（HyperText Markup Language）は、アプリのコンテンツの構造を作るために使います。ウェブサイト上の見出し、リスト、テーブル、リンクなどが何であるかをブラウザに伝える役割を担っています。[前のガイド](/app)で生成されたファイルもHTMLで構成されており、さらに拡張するためにRubyのコードを追加しています。
 
-`app/views/ideas/index.html`ファイルを開くと、以下が表示されるでしょう。例えばこのファイルの `<div>` タグで始まる部分はHTMLタグの開始を表し、スラッシュ記号で始まる部分 `</div>` はHTMLタグの終了を表します。このHTMLタグに対して `style`、`id`、`class` などのあらゆるプロパティを追加することができます。
+`app/views/ideas/index.html.erb`ファイルを開くと、以下が表示されるでしょう。例えばこのファイルの `<div>` タグで始まる部分はHTMLタグの開始を表し、スラッシュ記号で始まる部分 `</div>` はHTMLタグの終了を表します。このHTMLタグに対して `style`、`id`、`class` などのあらゆるプロパティを追加することができます。
 
 {% highlight erb %}
 <h1>Ideas</h1>


### PR DESCRIPTION
https://github.com/railsgirls/guides.railsgirls.com/pull/543 英語版の方にもプルリクエストを作成済みです。

https://guides.railsgirls.com/html-and-css に「`app/views/ideas/index.html`ファイルを開くと」とありますが、`rails generate scaffold idea name:string description:text picture:string` で生成されるファイルはapp/views/ideas/index.html.erbのようです。
このプルリクエストではガイドの側を「`app/views/ideas/index.html.erb`ファイルを開くと」に変更します。

`rails generate scaffold idea name:string description:text picture:string` を実行したときのスクリーンショット:
<img width="505" alt="screenshot" src="https://github.com/railsgirls-jp/railsgirls.jp/assets/14245262/6d4ce27f-e050-45e1-969e-eab0eb7422b1">
