### PR TITLE
Add step to start rails server

### DIFF
--- a/_pages/uploads.md
+++ b/_pages/uploads.md
@@ -103,6 +103,8 @@ mount_uploader :picture, PictureUploader
 <%= form.file_field :picture %>
 {% endhighlight %}
 
+`rails server`を実行してRailsサーバーを起動します。
+
 ブラウザで<http://localhost:3000/ideas/new>を開きましょう。 新しいフォームでは、 `picture` フィールドに初めとは異なる要素が表示されるようになりました。テキストフィールドの代わりにファイル選択ツールが表示され、「参照...」または「ファイルを選択」ボタンに変更されています。
 新しいデータを登録するためにフォームに情報を記入し、今回は新たに実装した画像アップロード機能を使って画像も選択します。あなたのパソコンにある任意の画像で構いません。
 場合によっては、 *TypeError: can't cast ActionDispatch::Http::UploadedFile to string* というエラーが起きることもあります。エラーになった場合は、 `app/views/ideas/_form.html.erb` の


### PR DESCRIPTION
https://github.com/railsgirls/guides.railsgirls.com/pull/544 英語版の方にもプルリクエスト作成済みです。

https://railsgirls.jp/uploads
gem "carrierwave "などを追加してbundle installする前にrailsサーバを停止するよう指示がありますが、その後railsサーバを起動するステップがありません。
http://localhost:3000/ideas/new にアクセスするステップの前に、「`rails server`を実行してRailsサーバーを起動します。」という行を足してみました。

```
{% highlight sh %}
rails server
{% endhighlight %}
```
と書くほど重要な手順というわけでもないので簡単に1行で書くだけにしています。