### PR TITLE
Change the directory name from ‘_posts’ to _pages in README after executing `rake post` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ bundle exec jekyll serve --watch
 $ bundle exec rake post title="my fabulous post"
 ```
 
-を実行すると、`YYYY-MM-DD-my-fabulous-post.markdown` というテンプレートが `_posts` ディレクトリに作られるので、これを編集します。`_posts` ディレクトリ以下のファイルは最初の部分に permalink の記述がなければ、ブログポストして扱われます。permalink がある場合は、どこかのページから permalink で指定した URL へリンクします。
+を実行すると、`YYYY-MM-DD-my-fabulous-post.markdown` というテンプレートが `_pages` ディレクトリに作られるので、これを編集します。`_pages` ディレクトリ以下のファイルは最初の部分に permalink の記述がなければ、ブログポストして扱われます。permalink がある場合は、どこかのページから permalink で指定した URL へリンクします。
 
 ## 独立したページを追加
 


### PR DESCRIPTION
READMEにて、新規ページ作成の手順は以下のように記載されています。
```md
$ bundle exec rake post title="my fabulous post"

を実行すると、YYYY-MM-DD-my-fabulous-post.markdown というテンプレートが _posts ディレクトリに作られるので、これを編集します。_posts ディレクトリ以下のファイルは最初の部分に permalink の記述がなければ、ブログポストして扱われます。
```

ですが、このコマンドを実行すると、`_pages`配下に新規ページが作られます。
```sh
❯ bundle exec rake post title="my fabulous post"
Creating new post: ./_pages/2023-10-29-my-fabulous-post.markdown
```
この`_pages`配下への新規ページ作成は、#608 のPRによる変更のようです。ただ、READMEへの反映が漏れていたようでしたので、今回のPRで修正を提案します。