### PR TITLE
ガイド下部に挿入されている共通パーツのメッセージを翻訳した

### DIFF
--- a/_layouts/guide.md
+++ b/_layouts/guide.md
@@ -5,5 +5,5 @@ layout: default
 <article class="guide">
 {{ content }}
 <hr>
-Want to learn more? <a href="/">View more guides!</a>
+もっと学びたいですか？ <a href="/">他のガイドも見てみましょう！</a>
 </article>


### PR DESCRIPTION
https://railsgirls.jp/ruby-intro
共通メッセージが英語のままだったため修正しました。

![FireShot Capture 050 - Rails Girls - Japanese - localhost](https://github.com/railsgirls-jp/railsgirls.jp/assets/76797372/881e74e8-32ac-409f-8ca4-8e3a0a3cb04a)

close #769 