### PR TITLE
過去のイベントページのTokyo 15thのリンク先URLを修正

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -19,7 +19,7 @@ title: "Rails Girls Events"
     <h3>Rails Girls Nagasaki 1st<small>2023/04/14〜2023/04/15</small></h3>
   </a>
 
-  <a href="https://railsgirls.com/tokyo.html" class="span4 event" style="background:url(/images/events/RailsGirlsTokyo15th-banner.png) 0px 0px / 100% no-repeat;">
+  <a href="https://railsgirls.com/tokyo-2023-04-08.html" class="span4 event" style="background:url(/images/events/RailsGirlsTokyo15th-banner.png) 0px 0px / 100% no-repeat;">
     <h3>Rails Girls Tokyo 15th<small>2023/04/07〜2023/04/08</small></h3>
   </a>
 


### PR DESCRIPTION
# 概要

下記が原因で、過去のイベントページのTokyo 15thをクリックするとTokyo 16thのイベントページへ遷移していたので修正しました。
- Tokyo 16thのページが作成されて、そちらのURLが`https://railsgirls.com/tokyo.html`になった
- 過去のイベントページのTokyo 15thのリンク先URLが`https://railsgirls.com/tokyo.html`のままだった

# 挙動確認

## Before
- Tokyo 15thのリンクをクリックすると、Tokyo 16thのイベントページに遷移してしまう

https://github.com/railsgirls-jp/railsgirls.jp/assets/72296262/4c9c997e-3acd-45c5-bb33-9f12d8d33572

## After
- Tokyo 15thのリンクをクリックすると、Tokyo 15thのイベントページに遷移する

https://github.com/railsgirls-jp/railsgirls.jp/assets/72296262/7cbc6bfa-a525-42dc-8d7d-11cb2139c545


