### PR TITLE
Resume html proofer

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -40,15 +40,11 @@ jobs:
       id: pages
       uses: actions/configure-pages@v3
 
-    - name: 🔧 Build static pages
+    - name: 🔧 Build static pages & ✅ Test static pages
       run: |
-        bundle exec jekyll build
+        bundle exec rake test
       env:
         JEKYLL_ENV: production
-
-    # - name: ✅ Test static pages
-    #   run: |
-    #     bundle exec rake test
 
     - name: ☁️ Upload artifact
       uses: actions/upload-pages-artifact@v1

--- a/Rakefile
+++ b/Rakefile
@@ -187,5 +187,6 @@ task :test do
     ],
   }
 
+  sh("bundle exec jekyll build")
   HTMLProofer.check_directory('_site', options).run
 end

--- a/_posts/blog/2017-09-23-rubykaigi2017-support-for-alumni.markdown
+++ b/_posts/blog/2017-09-23-rubykaigi2017-support-for-alumni.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: RubyKaigi2017 参加支援についてのご報告
-date: 2017-09-23 16:16:22 GMT
+date: 2017-09-23
 image: /images/blog/DKJjw4LVAAAeWAj.jpg
 ---
 <p><p>Rails Girls Japan では、この度、これまでのRails Girls イベントの参加者の中から、


### PR DESCRIPTION
CIで停止されていたhtml-prooferですが、最近の更新で内部リンク切れがなくなったので再開したいなと思っています

* RubyKaigi2017 参加支援のページの更新
    * htmlだとリンク切れチェックがうまくいかなかったのでmarkdownにしました
    * dateの部分にtimeがあるとbuildをした際の出力ディレクトリの日付がずれてしまうため時刻を削除しました
* Rakefileの更新
    * html-prooferはbuild結果に対して行われるため、test時にbuildも行うようにしました
