### PR TITLE
表示関連の軽微な修正を反映

### DIFF
--- a/_posts/blog/2024-01-28-start-accepting-rubykaigi2024-support-for-alumni.markdown
+++ b/_posts/blog/2024-01-28-start-accepting-rubykaigi2024-support-for-alumni.markdown
@@ -19,6 +19,10 @@ div.past-supoorts img.photo {
     object-fit: cover;
 }
 
+img.photo:hover {
+  opacity: 0.8;
+}
+
 div.past-supoorts span.event-name {
   color: #fff;
   background-color: #d3360b;

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ title: 日本語版ガイド
 
 <div id="container" class="row clearfix">
   <a href="https://railsgirls.com/tokyo.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_16th_OGP.png) center -15px / 100% no-repeat;">
-    <h3>>Tokyo 16th<small>2024/03/01〜2024/03/02</small></h3>
+    <h3>Tokyo 16th<small>2024/03/01〜2024/03/02</small></h3>
   </a>
 
   <!-- ↓直近で開催予定のイベントページがまだない場合 -->


### PR DESCRIPTION
- トップページのupcomingのイベント名に余計な `>` が紛れ込んでいたので削除しました
- [RubyKaigi 2024の支援募集ブログ](https://railsgirls.jp/2024/01/28/start-accepting-rubykaigi2024-support-for-alumni/)下部にある、過去の支援報告の画像リンクがリンクであることが分かりづらいと感じたので、hoverしたときに写真を少し薄くするスタイルを追加しました
