### PR TITLE
Rails Girls Tokyo 16thを過去のイベントに移動

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -4,16 +4,22 @@ title: "Rails Girls Events"
 ---
 
 <!-- content -->
-
+<!-- ↓直近開催予定のイベントページがある場合にコメントアウトを外して内容を更新 -->
+<!--
 <div id="container" class="row clearfix">
   <h2>近日開催のイベント</h2>
   <a href="https://railsgirls.com/tokyo.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_16th_OGP.png) center -15px / 100% no-repeat;">
     <h3>Tokyo 16th<small>2024/03/01〜2024/03/02</small></h3>
   </a>
-</div>
+</div> -->
+<!-- ↑直近開催予定のイベントページがある場合にコメントアウトを外して内容を更新 -->
 
 <div id="container" class="row clearfix">
   <h2>過去のイベント</h2>
+  <a href="https://railsgirls.com/tokyo.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_16th_OGP.png) center -15px / 100% no-repeat;">
+    <h3>Tokyo 16th<small>2024/03/01〜2024/03/02</small></h3>
+  </a>
+
   <a href="https://railsgirls.com/matsue-5th.html" class="span4 event" style="background:url(https://railsgirls.com/images/matsue/5th-logo.png) center 0px / 40% no-repeat;">
     <h3>Matsue 5th<small>2023/11/11</small></h3>
   </a>

--- a/index.html
+++ b/index.html
@@ -27,16 +27,16 @@ title: 日本語版ガイド
 <h2>日本で近日開催のイベント</h2>
 
 <div id="container" class="row clearfix">
-  <a href="https://railsgirls.com/tokyo.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_16th_OGP.png) center -15px / 100% no-repeat;">
+  <!-- <a href="https://railsgirls.com/tokyo.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_16th_OGP.png) center -15px / 100% no-repeat;">
     <h3>Tokyo 16th<small>2024/03/01〜2024/03/02</small></h3>
-  </a>
+  </a> -->
 
   <!-- ↓直近で開催予定のイベントページがまだない場合 -->
-  <!--
+
   <div class="span12" style="padding-bottom: 2em;">
     coming soon..
   </div>
-  -->
+
   <!-- ↑直近で開催予定のイベントページがまだない場合 -->
 </div>
 


### PR DESCRIPTION
## やったこと
- Rails Girls ガイドのトップの「日本で近日開催のイベント」を`coming soon..`に更新
- EventsページでRails Girls Tokyo 16thを過去のイベントに移動

<img width="604" alt="Monosnap Rails Girls - Japanese 2024-03-04 21-19-49" src="https://github.com/railsgirls-jp/railsgirls.jp/assets/76797372/ddc6d43d-a502-4c27-bf7b-1cef3a28e14a">
<img width="589" alt="Monosnap Rails Girls - Japanese 2024-03-04 21-20-50" src="https://github.com/railsgirls-jp/railsgirls.jp/assets/76797372/a377215c-91ea-4110-a284-82d002f2af20">
