### PR TITLE
Add pixiv inc. to 2024 annual sponsors

### DIFF
--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -110,6 +110,12 @@ title: Rails Girls Japan Sponsors
 
 <hr>
 
+<h2>2024年</h2>
+<h4>年間スポンサー</h4>
+<div class="year-sponsor">
+  <a class="year-sponsor" href="https://www.pixiv.co.jp/"><img src="/images/sponsors/pixiv.png" alt="ピクシブ株式会社" ></a>
+</div>
+
 <h2>2023年</h2>
 <h4>年間スポンサー</h4>
 <div class="silver-sponsors">


### PR DESCRIPTION
2024年度の年間スポンサーにお申込みいただいていたピクシブ株式会社様をスポンサー一覧ページへ掲載しました。