### PR TITLE
fix: change the filename SQLite3 in accordance with Rails 7.1

### DIFF
--- a/_pages/deployment/fly-io.md
+++ b/_pages/deployment/fly-io.md
@@ -59,7 +59,7 @@ Railsの複数ある環境が何かを説明しましょう。`Production` と�
 {% highlight yaml %}
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: storage/production.sqlite3
 {% endhighlight %}
 
 以下のように変更します。

--- a/_pages/digital-ocean.md
+++ b/_pages/digital-ocean.md
@@ -51,7 +51,7 @@ Railsの複数ある環境が何かを説明しましょう。`Production` と�
 {% highlight yaml %}
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: storage/production.sqlite3
 {% endhighlight %}
 
 以下のように変更します。

--- a/_pages/heroku.md
+++ b/_pages/heroku.md
@@ -138,7 +138,7 @@ bundle install
 {% highlight ruby %}
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: storage/production.sqlite3
 {% endhighlight %}
 
 を次のように変更してください。:


### PR DESCRIPTION
In Rails 7.1, the database filename for SQLite3 was changed: see https://github.com/rails/rails/pull/46699

- Upstream: https://github.com/railsgirls/guides.railsgirls.com/pull/578
- Ref: https://github.com/rails/rails/pull/46699
- Acknowledge: @rlis12099