### PR TITLE
Fix style and tokyo 16th link

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -28,7 +28,7 @@ title: "Rails Girls Events"
     <h3>Nagoya 6th<small>2024/03/30</small></h3>
   </a>
 
-  <a href="https://railsgirls.com/tokyo.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_16th_OGP.png) center -15px / 100% no-repeat;">
+  <a href="https://railsgirls.com/tokyo-2024-03-01.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_16th_OGP.png) center -15px / 100% no-repeat;">
     <h3>Tokyo 16th<small>2024/03/01〜2024/03/02</small></h3>
   </a>
 

--- a/index.html
+++ b/index.html
@@ -33,8 +33,6 @@ title: 日本語版ガイド
     <a href="https://railsgirls.com/nagasaki_2nd.html" class="span4 event" style="background:url(/images/railsgirls-sq.png) center -20px  / 60% no-repeat;">
       <h3>Rails Girls Nagasaki 2nd<small>2025/02/14〜2025/02/15</small></h3>
     </a>                                                                                                                                          
-  </div>
-  <div class="span12" style="padding-bottom: 2em;">
     <a href="https://railsgirls.com/tokyo-2025-02-21.html" class="span4 event" style="background:url(/images/railsgirls-sq.png) center -20px  / 60% no-repeat;">
       <h3>Rails Girls Tokyo 17th<small>2025/02/21〜2025/02/22</small></h3>
     </a>                                                                                                                                          


### PR DESCRIPTION
イベント情報が縦並びになってしまっていたので、横並びに修正
![image](https://github.com/user-attachments/assets/eab654dd-bcd9-405b-acb7-98cba33f9d11)

前回のTokyo開催のURLが変更されたので、修正
