### PR TITLE
actions/upload-pages-artifact アクションをv3に引き上げ

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -47,7 +47,7 @@ jobs:
         JEKYLL_ENV: production
 
     - name: ☁️ Upload artifact
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
 
   deploy:
     environment:


### PR DESCRIPTION
`actions/upload-pages-artifact@v1` が依存している `actions/upload-artifact@v3` がdeprecatedになった関係で #833 でビルドが失敗していたので、設定を修正してバージョンの引き上げを行いました。