### PR TITLE
Bump up latest release versions with package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Thumbs.db
 .idea
 
 *~
+
+node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.1",
   "comment": "このファイルはダミーです。GitHubに脆弱性を検知してもらうためだけに置いています。利用するJavaScriptのバージョン更新にあわせて、本ファイルのバージョンを更新して使用する事を想定しています。",
   "dependencies": {
-    "prefixfree": "1.0.6",
+    "prefixfree": "1.0.0",
     "jquery": "3.5.0",
-    "js-cookie": "1.3.1",
-    "bootstrap": "2.3.2"
+    "js-cookie": "1.5.0",
+    "bootstrap": "3.1.1"
   }
 }


### PR DESCRIPTION
現状の package.json には npmjs.org には存在しないバージョンが含まれており、その影響で cloudflare pages の preview に失敗するので実際にこのバージョンを使うかは別に、存在する最低バージョンに上げておきます。

実際に使っているライブラリとバージョンを揃えるのは別途やります。