### PR TITLE
トップページのupcoming listのロゴが表示できなくなっていたので修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,13 +27,10 @@ title: 日本語版ガイド
 <h2>日本で近日開催のイベント</h2>
 
 <div id="container" class="row clearfix">
+  <a href="https://railsgirls.com/tokyo-2025-02-21.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_17th_logo.jpg) center -20px  / 60% no-repeat;">
+    <h3>Rails Girls Tokyo 17th<small>2025/02/21〜2025/02/22</small></h3>
+  </a>
   <!-- ↓直近で開催予定のイベントページがまだない場合 -->
-
-  <div class="span12" style="padding-bottom: 2em;">
-    <a href="https://railsgirls.com/tokyo-2025-02-21.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_17th_logo.jpg) center -20px  / 60% no-repeat;">
-      <h3>Rails Girls Tokyo 17th<small>2025/02/21〜2025/02/22</small></h3>
-    </a>
-  </div>
   <!-- ↑直近で開催予定のイベントページがまだない場合 -->
 </div>
 

--- a/index.html
+++ b/index.html
@@ -31,6 +31,11 @@ title: 日本語版ガイド
     <h3>Rails Girls Tokyo 17th<small>2025/02/21〜2025/02/22</small></h3>
   </a>
   <!-- ↓直近で開催予定のイベントページがまだない場合 -->
+  <!--
+  <div class="span12" style="padding-bottom: 2em;">
+    coming soon..
+  </div>  
+  -->
   <!-- ↑直近で開催予定のイベントページがまだない場合 -->
 </div>
 


### PR DESCRIPTION
## before
![image](https://github.com/user-attachments/assets/8c06761a-ef4a-4389-8aba-4c4f7f22c207)

## after
![image](https://github.com/user-attachments/assets/dd53149d-eb6c-4c90-a2cb-c5aef914ce4e)
