### PR TITLE
Tokyo 17thを過去のイベント一覧へ移動

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -8,14 +8,19 @@ title: "Rails Girls Events"
 
 <div id="container" class="row clearfix">
   <h2>近日開催のイベント</h2>
-  <a href="https://railsgirls.com/tokyo-2025-02-21.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_17th_logo.jpg) center -20px  / 60% no-repeat;">
-    <h3>Rails Girls Tokyo 17th<small>2025/02/21〜2025/02/22</small></h3>
-  </a>
+  <!-- ↓直近で開催予定のイベントページがまだない場合 -->
+  <div class="span12" style="padding-bottom: 2em;">
+    coming soon..
+  </div>  
+  <!-- ↑直近で開催予定のイベントページがまだない場合 -->
 </div>
 <!-- ↑直近開催予定のイベントページがある場合にコメントアウトを外して内容を更新 -->
 
 <div id="container" class="row clearfix">
   <h2>過去のイベント</h2>
+  <a href="https://railsgirls.com/tokyo-2025-02-21.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_17th_logo.jpg) center -20px  / 60% no-repeat;">
+    <h3>Rails Girls Tokyo 17th<small>2025/02/21〜2025/02/22</small></h3>
+  </a>
 
   <a href="https://qiita.com/advent-calendar/2024/railsgirlsjapan" class="span4 event" style="background:url(/images/railsgirls-sq.png) 0px -70px / 100% no-repeat;">
     <h3>Rails Girls Japan Advent Calendar 2024<small>2024/12/01〜2024/12/25</small></h3>

--- a/index.html
+++ b/index.html
@@ -27,15 +27,10 @@ title: 日本語版ガイド
 <h2>日本で近日開催のイベント</h2>
 
 <div id="container" class="row clearfix">
-  <a href="https://railsgirls.com/tokyo-2025-02-21.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_17th_logo.jpg) center -20px  / 60% no-repeat;">
-    <h3>Rails Girls Tokyo 17th<small>2025/02/21〜2025/02/22</small></h3>
-  </a>
   <!-- ↓直近で開催予定のイベントページがまだない場合 -->
-  <!--
   <div class="span12" style="padding-bottom: 2em;">
     coming soon..
   </div>  
-  -->
   <!-- ↑直近で開催予定のイベントページがまだない場合 -->
 </div>
 


### PR DESCRIPTION
Tokyo 17th開催お疲れ様でした 🎉 

* トップページのupcoming listから削除
    * coming soonの文言を表示するように修正
* イベント一覧(/events/)で過去イベント一覧へ移動