### PR TITLE
Fix: Prevent oversized images by setting max-width: 100%

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -752,3 +752,7 @@ pre {
   border: 1px solid rgba(0, 0, 0, 0.15);
   border-radius: 4px;
 }
+
+img {
+  max-width: 100%;
+}


### PR DESCRIPTION
RailsGirlsガイドで、画像が大きすぎて画面内に収まっていない問題を修正するPRです。
現在はwidthが指定されていないことによって画像の元のサイズそのまま表示されているようです。	3456 × 2234 pxで表示されている画像もあります。

**←after | before →** 
beforeの場合画像が大きすぎて全体が把握できない
<img width="1469" alt="スクリーンショット 2025-06-28 15 18 07" src="https://github.com/user-attachments/assets/0f7a9414-ccb5-4d31-b378-55ce7c252152" />

**←after | before →** 
beforeの場合画像が大きすぎて全体が把握できない
<img width="1466" alt="スクリーンショット 2025-06-28 15 17 36" src="https://github.com/user-attachments/assets/4b1355c6-c503-43aa-9a43-2800f0303ccb" />

**←after | before →** 
元々小さい画像の場合、変更後もレイアウトが崩れていないこと
<img width="1469" alt="スクリーンショット 2025-06-28 15 18 40" src="https://github.com/user-attachments/assets/50fb120e-48e8-423b-8ef7-bf6f9b617b5d" />