### PR TITLE
Add Rails Girls Tokyo 18th event

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -20,6 +20,12 @@ title: "Rails Girls Events"
       <h3>Rails Girls Sapporo 2nd<small>2025/10/17〜2025/10/18</small></h3>
     </div>
   </a>
+
+  <a href="https://railsgirls.com/tokyo-2026-02-13.html" class="span4 event" style="background:url(/images/railsgirls-sq.png) center -20px  / 60% no-repeat;">
+    <div>
+      <h3>Rails Girls Tokyo 18th<small>2026年2月</small></h3>
+    </div>
+  </a>
 </div>
 <!-- ↑直近開催予定のイベントページがある場合にコメントアウトを外して内容を更新 -->
 

--- a/index.html
+++ b/index.html
@@ -36,6 +36,11 @@ title: 日本語版ガイド
       <h3>Rails Girls Sapporo 2nd<small>2025/10/17〜2025/10/18</small></h3>
     </div>
   </a>
+  <a href="https://railsgirls.com/tokyo-2026-02-13.html" class="span4 event" style="background:url(/images/railsgirls-sq.png) center -20px  / 60% no-repeat;">
+    <div>
+      <h3>Rails Girls Tokyo 18th<small>2026年2月</small></h3>
+    </div>
+  </a>
   <!-- ↑直近で開催予定のイベントページがまだない場合 -->
 </div>
 


### PR DESCRIPTION
## 概要
Rails Girls Tokyo 18thのイベント情報をrailsgirls.jpに追加しました。

## 変更内容
- トップページ（index.html）の「近日開催のイベント」セクションにTokyo 18thを追加
- イベント一覧ページ（events/index.html）の「近日開催のイベント」セクションにTokyo 18thを追加
- 開催予定：2026年2月（日付は確定後に更新）
- リンク先：https://railsgirls.com/tokyo-2026-02-13.html （10月12日20時時点で反映前）
- ロゴ：デフォルトのrailsgirls-sq.pngを使用（後で差し替え）

## 確認事項
- [x] トップページでTokyo 18thが正しく表示される
- [x] イベント一覧ページでTokyo 18thが正しく表示される
- [x] 時系列順序が正しい（Sapporo 2nd → Tokyo 18th）