### PR TITLE
Archive Sapporo 2nd

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -15,12 +15,6 @@ title: "Rails Girls Events"
   </div>
   -->
   <!-- ↑直近で開催予定のイベントページがまだない場合 -->
-  <a href="https://railsgirls.com/sapporo-2nd.html" class="span4 event" style="background: url(/images/events/sapporo_2nd_logo.png) 70px -10px / 55% no-repeat;">
-    <div>
-      <h3>Rails Girls Sapporo 2nd<small>2025/10/17〜2025/10/18</small></h3>
-    </div>
-  </a>
-
   <a href="https://railsgirls.com/tokyo-2026-02-13.html" class="span4 event" style="background:url(/images/railsgirls-sq.png) center -20px  / 60% no-repeat;">
     <div>
       <h3>Rails Girls Tokyo 18th<small>2026年2月</small></h3>
@@ -31,6 +25,12 @@ title: "Rails Girls Events"
 
 <div id="container" class="row clearfix">
   <h2>過去のイベント</h2>
+
+  <a href="https://railsgirls.com/sapporo-2nd.html" class="span4 event" style="background: url(/images/events/sapporo_2nd_logo.png) 70px -10px / 55% no-repeat;">
+    <div>
+      <h3>Rails Girls Sapporo 2nd<small>2025/10/17〜2025/10/18</small></h3>
+    </div>
+  </a>
 
   <a href="https://railsgirls.com/izumo-1st.html" class="span4 event" style="background: url(/images/events/izumo-1st-logo.png) center -5px / 55% no-repeat;">
     <div>
@@ -44,7 +44,7 @@ title: "Rails Girls Events"
 
   <a href="https://qiita.com/advent-calendar/2024/railsgirlsjapan" class="span4 event" style="background:url(/images/railsgirls-sq.png) 0px -70px / 100% no-repeat;">
     <h3>Rails Girls Japan Advent Calendar 2024<small>2024/12/01〜2024/12/25</small></h3>
-  </a>    
+  </a>
 
   <a href="https://railsgirls.com/nagasaki_2nd.html" class="span4 event" style="background:url(/images/events/nagasaki/logo-2nd.png) center -20px  / 60% no-repeat;">
     <h3>Rails Girls Nagasaki 2nd<small>2025/02/14〜2025/02/15</small></h3>

--- a/index.html
+++ b/index.html
@@ -31,11 +31,6 @@ title: 日本語版ガイド
   <!-- <div class="span12" style="padding-bottom: 2em;">
     coming soon..
   </div> -->
-  <a href="https://railsgirls.com/sapporo-2nd.html" class="span4 event" style="background: url(/images/events/sapporo_2nd_logo.png) 70px -10px / 55% no-repeat;">
-    <div>
-      <h3>Rails Girls Sapporo 2nd<small>2025/10/17〜2025/10/18</small></h3>
-    </div>
-  </a>
   <a href="https://railsgirls.com/tokyo-2026-02-13.html" class="span4 event" style="background:url(/images/railsgirls-sq.png) center -20px  / 60% no-repeat;">
     <div>
       <h3>Rails Girls Tokyo 18th<small>2026年2月</small></h3>


### PR DESCRIPTION
Updated the Rails Girls Sapporo 2nd event on the events page as a past event.
This pull request may conflict with #904.
Please merge #904 first, and I will fix any conflicts if they occur.
Please review.

---

@emorima 

Rails Girls Sapporo 2ndを「近日開催のイベント」から「過去のイベント」へ移動しました。
#904 とコンフリクトする可能性があるため、#904 を先にマージしていただき、コンフリクトがあればこちらで修正します。
お手隙の際にレビューをお願いいたします。