### PR TITLE
Fix Tokyo date

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -6,7 +6,7 @@ title: "Rails Girls Events"
 <!-- content -->
 <!-- ↓直近開催予定のイベントページがある場合にコメントアウトを外して内容を更新 -->
 
-<div id="container" class="row clearfix">
+<div id="container-coming" class="row clearfix">
   <h2>近日開催のイベント</h2>
   <!-- ↓直近で開催予定のイベントページがまだない場合 -->
   <!--
@@ -28,7 +28,7 @@ title: "Rails Girls Events"
 </div>
 <!-- ↑直近開催予定のイベントページがある場合にコメントアウトを外して内容を更新 -->
 
-<div id="container" class="row clearfix">
+<div id="container-past" class="row clearfix">
   <h2>過去のイベント</h2>
 
   <a href="https://railsgirls.com/sapporo-2nd.html" class="span4 event" style="background: url(/images/events/sapporo_2nd_logo.png) 70px -10px / 55% no-repeat;">

--- a/events/index.html
+++ b/events/index.html
@@ -22,7 +22,7 @@ title: "Rails Girls Events"
   </a>
   <a href="https://railsgirls.com/tokyo-2026-02-13.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_18th_OGP.png) center -20px  / 100% no-repeat;">
     <div>
-      <h3>Rails Girls Tokyo 18th<small>2025/02/13〜2025/02/14</small></h3>
+      <h3>Rails Girls Tokyo 18th<small>2026/02/13〜2026/02/14</small></h3>
     </div>
   </a>
 </div>

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@ title: 日本語版ガイド
   <!-- <div class="span12" style="padding-bottom: 2em;">
     coming soon..
   </div> -->
+  <!-- ↑直近で開催予定のイベントページがまだない場合 -->
   <a href="https://railsgirls.com/nagoya.html" class="span4 event" style="background:url(/images/railsgirls-sq.png) 0px -70px / 100% no-repeat;">
     <div>
       <h3>Rails Girls Nagoya 7th<small>2026/03/27〜2026/03/28</small></h3>
@@ -41,7 +42,6 @@ title: 日本語版ガイド
       <h3>Rails Girls Tokyo 18th<small>2026/02/13〜2026/02/14</small></h3>
     </div>
   </a>
-  <!-- ↑直近で開催予定のイベントページがまだない場合 -->
 </div>
 
 Rails Girls Japanの<a href="https://twitter.com/RailsGirlsJapan">X(旧Twitter)</a>や<a href="https://www.instagram.com/railsgirlsjapan/">Instagram</a>では、日本国内で開催するRails Girlsイベント情報などをお知らせしています！

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@ title: 日本語版ガイド
   </a>
   <a href="https://railsgirls.com/tokyo-2026-02-13.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_18th_OGP.png) center -20px  / 100% no-repeat;">
     <div>
-      <h3>Rails Girls Tokyo 18th<small>2025/02/13〜2025/02/14</small></h3>
+      <h3>Rails Girls Tokyo 18th<small>2026/02/13〜2026/02/14</small></h3>
     </div>
   </a>
   <!-- ↑直近で開催予定のイベントページがまだない場合 -->


### PR DESCRIPTION
以下の問題を修正しました。

- Rails Girls Tokyo 18thの開催年が2025年になっていたので2026年に修正
- idが重複してHTML的にinvalidだったので修正
- コメント行が不自然な位置で分断されていたので修正

<img width="885" height="474" alt="1" src="https://github.com/user-attachments/assets/60bbbe99-c1a1-46ec-b761-cc3c0af8f2d1" />
<img width="1084" height="626" alt="2" src="https://github.com/user-attachments/assets/3d091e27-76c6-4315-80be-883c05d79dbf" />
