### PR TITLE
Fix link text

### DIFF
--- a/_includes/main_guides.md
+++ b/_includes/main_guides.md
@@ -6,7 +6,7 @@
 
 * ガイド 1: [はじめに](/start) {% if page.permalink == 'start' %}(このページです！){% endif %}
 * ガイド 2: [ツールについて知ろう](/tools) {% if page.permalink == 'tools' %}(このページです！){% endif %}
-* ガイド 3: [Railsインストールガイド](/install) {% if page.permalink == 'install' %}(このページです！){% endif %}
+* ガイド 3: [Rails Girls インストール・レシピ](/install) {% if page.permalink == 'install' %}(このページです！){% endif %}
   - [macOS 用セットアップ](/install/macos) {% if page.permalink == 'install/macos' %}(このページです！){% endif %}
   - [Windows 用セットアップ](/install/windows) {% if page.permalink == 'install/windows' %}(このページです！){% endif %}
   - [Windows 用セットアップ（WSL）](/install/windows-wsl) {% if page.permalink == 'install/windows-wsl' %}(このページです！){% endif %}

--- a/_includes/main_guides.md
+++ b/_includes/main_guides.md
@@ -17,7 +17,7 @@
 * ガイド 4: [はじめてのアプリを作る](/app) {% if page.permalink == 'app' %}(このページです！){% endif %}
 * ガイド 5: [HTMLとCSSを使ってアプリをスタイリングしよう](/html-and-css) {% if page.permalink == 'html-and-css' %}(このページです！){% endif %}
 * ガイド 6: [アプリに新しいページを追加しよう](/new-page) {% if page.permalink == 'new-page' %}(このページです！){% endif %}
-* ガイド 7: [あなたのアプリに新しいホーム画面を追加しよう](/new-homepage) {% if page.permalink == 'new-homepage' %}(このページです！){% endif %}
+* ガイド 7: [新しいホーム画面を追加しよう](/new-homepage) {% if page.permalink == 'new-homepage' %}(このページです！){% endif %}
 * ガイド 8: [画像アップロード機能を追加しよう](/uploads) {% if page.permalink == 'uploads' %}(このページです！){% endif %}
 * ガイド 9: [GitHub であなたのアプリのコードを公開しよう](/github) {% if page.permalink == 'github' %}(このページです！){% endif %}
 * ガイド 10: これらのサービスのどれかで [あなたのアプリをインターネットに公開しよう](/deployment) {% if page.permalink == 'deployment' %}(このページです！){% endif %}

--- a/_includes/main_guides.md
+++ b/_includes/main_guides.md
@@ -28,7 +28,7 @@
   - [anynines](/anynines) {% if page.permalink == 'anynines' %}(このページです！){% endif %}
   - [Engine Yard](/engineyard) {% if page.permalink == 'engineyard' %}(このページです！){% endif %}
 * ガイド 11: [HTML と CSS を使ってアイデアのページをデザインしてみよう](/design) {% if page.permalink == 'design' %}(このページです！){% endif %}
-* ガイド 12: [あなたのアプリにコメント出来るようにしましょう](/commenting) {% if page.permalink == 'commenting' %}(このページです！){% endif %}
+* ガイド 12: [コメント機能を追加しよう](/commenting) {% if page.permalink == 'commenting' %}(このページです！){% endif %}
 * ガイド 13: [Carrierwave を使って画像をリサイズしよう](/thumbnails) {% if page.permalink == 'thumbnails' %}(このページです！){% endif %}
 * ガイド 14: [RSpecでアプリをテストしよう](/testing-rspec) {% if page.permalink == 'testing-rspec' %}(このページです！){% endif %}
 

--- a/_includes/main_guides.md
+++ b/_includes/main_guides.md
@@ -29,7 +29,7 @@
   - [Engine Yard](/engineyard) {% if page.permalink == 'engineyard' %}(このページです！){% endif %}
 * ガイド 11: [HTML と CSS を使ってアイデアのページをデザインしてみよう](/design) {% if page.permalink == 'design' %}(このページです！){% endif %}
 * ガイド 12: [コメント機能を追加しよう](/commenting) {% if page.permalink == 'commenting' %}(このページです！){% endif %}
-* ガイド 13: [Carrierwave を使って画像をリサイズしよう](/thumbnails) {% if page.permalink == 'thumbnails' %}(このページです！){% endif %}
+* ガイド 13: [画像のサムネイルを作ってみよう](/thumbnails) {% if page.permalink == 'thumbnails' %}(このページです！){% endif %}
 * ガイド 14: [RSpecでアプリをテストしよう](/testing-rspec) {% if page.permalink == 'testing-rspec' %}(このページです！){% endif %}
 
 [全てのガイドを見る](/)

--- a/_includes/main_guides.md
+++ b/_includes/main_guides.md
@@ -12,8 +12,8 @@
   - [Windows 用セットアップ（WSL）](/install/windows-wsl) {% if page.permalink == 'install/windows-wsl' %}(このページです！){% endif %}
   - [Linux 用セットアップ](/install/linux) {% if page.permalink == 'install/linux' %}(このページです！){% endif %}
   - [仮想マシンにセットアップする](/install/virtual-machine) {% if page.permalink == 'install/virtual-machine' %}(このページです！){% endif %}
-  - [クラウドサービス Replit を使う](/install/replit) {% if page.permalink == 'install/replit' %}(このページです！){% endif %}
-  - [GitHub Codespaces を使う](/install/codespaces) {% if page.permalink == 'install/codespaces' %}(このページです！){% endif %}
+  - [クラウドサービス Replit を利用する](/install/replit) {% if page.permalink == 'install/replit' %}(このページです！){% endif %}
+  - [GitHub Codespaces を利用する](/install/codespaces) {% if page.permalink == 'install/codespaces' %}(このページです！){% endif %}
 * ガイド 4: [はじめてのアプリを作る](/app) {% if page.permalink == 'app' %}(このページです！){% endif %}
 * ガイド 5: [HTMLとCSSを使ってアプリをスタイリングしよう](/html-and-css) {% if page.permalink == 'html-and-css' %}(このページです！){% endif %}
 * ガイド 6: [アプリに新しいページを追加しよう](/new-page) {% if page.permalink == 'new-page' %}(このページです！){% endif %}

--- a/_includes/main_guides.md
+++ b/_includes/main_guides.md
@@ -27,7 +27,7 @@
   - [OpenShift](/openshift) {% if page.permalink == 'openshift' %}(このページです！){% endif %}
   - [anynines](/anynines) {% if page.permalink == 'anynines' %}(このページです！){% endif %}
   - [Engine Yard](/engineyard) {% if page.permalink == 'engineyard' %}(このページです！){% endif %}
-* ガイド 11: [HTML & CSS を使ってデザインしてみよう](/design) {% if page.permalink == 'design' %}(このページです！){% endif %}
+* ガイド 11: [HTML と CSS を使ってアイデアのページをデザインしてみよう](/design) {% if page.permalink == 'design' %}(このページです！){% endif %}
 * ガイド 12: [あなたのアプリにコメント出来るようにしましょう](/commenting) {% if page.permalink == 'commenting' %}(このページです！){% endif %}
 * ガイド 13: [Carrierwave を使って画像をリサイズしよう](/thumbnails) {% if page.permalink == 'thumbnails' %}(このページです！){% endif %}
 * ガイド 14: [RSpecでアプリをテストしよう](/testing-rspec) {% if page.permalink == 'testing-rspec' %}(このページです！){% endif %}

--- a/_includes/main_guides.md
+++ b/_includes/main_guides.md
@@ -25,7 +25,7 @@
   - [Heroku](/heroku) {% if page.permalink == 'heroku' %}(このページです！){% endif %}
   - [DigitalOcean](/digitalocean) {% if page.permalink == 'digitalocean' %}(このページです！){% endif %}
   - [OpenShift](/openshift) {% if page.permalink == 'openshift' %}(このページです！){% endif %}
-  - [Anynines](/anynines) {% if page.permalink == 'anynines' %}(このページです！){% endif %}
+  - [anynines](/anynines) {% if page.permalink == 'anynines' %}(このページです！){% endif %}
   - [Engine Yard](/engineyard) {% if page.permalink == 'engineyard' %}(このページです！){% endif %}
 * ガイド 11: [HTML & CSS を使ってデザインしてみよう](/design) {% if page.permalink == 'design' %}(このページです！){% endif %}
 * ガイド 12: [あなたのアプリにコメント出来るようにしましょう](/commenting) {% if page.permalink == 'commenting' %}(このページです！){% endif %}

--- a/_pages/activeadmin.md
+++ b/_pages/activeadmin.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Active Adminを使用したバックエンドの追加
+title: アプリにバックエンドを追加しよう(管理画面)
 permalink: backend-with-active-admin
 ---
 
-# Active Adminを使用したバックエンドの追加
+# アプリにバックエンドを追加しよう(管理画面)
 
 *Created by [Rasmus Kjellberg](https://www.rasmuskjellberg.se) / 翻訳者: Nana Matsuoka*
 

--- a/_pages/anynines.md
+++ b/_pages/anynines.md
@@ -1,10 +1,10 @@
 ---
 layout: main_guide
-title: Rails Girls on anynines
+title: anyninesであなたのアプリをオンラインにあげよう
 permalink: anynines
 ---
-　
-# anyninesを使用してインターネットに公開しよう!
+
+# anyninesであなたのアプリをオンラインにあげよう
 *Created by Floor Drees, [@floordrees](https://twitter.com/floordrees)* / *Translated by moegi, [@moegi_web](https://twitter.com/moegi_web)*
 
 {% coach %}

--- a/_pages/continuous-codeship.md
+++ b/_pages/continuous-codeship.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Continuous Deployment - cuz less hassle
+title: Codeship（およびHeroku）を使用した継続的デプロイ
 permalink: continuous
 ---
 
-# Codeshipを使用した継続的デプロイ
+# Codeship（およびHeroku）を使用した継続的デプロイ
 
 *Created by Floor Drees, [@floordrees](https://twitter.com/floordrees)* / *翻訳者: [@peno022](https://twitter.com/peno022)*
 

--- a/_pages/continuous-travis.md
+++ b/_pages/continuous-travis.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Continuous Deployment - cuz less hassle
+title: Travis（およびanynines）を使用した継続的デプロイ
 permalink: continuous-travis
 ---
 
-# Travisを使用した継続的デプロイ
+# Travis（およびanynines）を使用した継続的デプロイ
 
 *Created by Floor Drees, [@floordrees](https://twitter.com/floordrees)* / *翻訳者: [@monya_tto](https://twitter.com/monya_tto)*
 

--- a/_pages/devise.md
+++ b/_pages/devise.md
@@ -1,10 +1,10 @@
 ---
 layout: guide
-title: Devise で認証機能を追加
+title: Deviseによる認証を追加してみよう
 permalink: devise
 ---
 
-# Devise で認証機能を追加
+# Deviseによる認証を追加してみよう
 
 *Created by Piotr Steininger, [@polishprince](https://twitter.com/polishprince). Updated by Ernesto Jimenez, [@ernesto_jimenez](https://twitter.com/ernesto_jimenez)*, and [Hasan Diwan](https://units.d8u.us/twitter?src`=railsgirlsGuide)*
 

--- a/_pages/diary-app.md
+++ b/_pages/diary-app.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Rails Girls Diary tutorial
+title: Ruby on Railsで初めての日記アプリを作ろう
 permalink: diary-app
 ---
 

--- a/_pages/digital-ocean.md
+++ b/_pages/digital-ocean.md
@@ -1,6 +1,6 @@
 ---
 layout: main_guide
-title: Rails Girls on DigitalOcean
+title: DigitalOceanであなたのアプリをオンラインにあげよう
 description: "このガイドに沿ってDigitalOceanであなたのアプリをデプロイしよう"
 permalink: digitalocean
 ---

--- a/_pages/engineyard.md
+++ b/_pages/engineyard.md
@@ -1,10 +1,10 @@
 ---
 layout: main_guide
-title: Rails Girls on Engine Yard
+title: Engine Yardであなたのアプリをオンラインにあげよう
 permalink: engineyard
 ---
 
-# Engine Yardを使用してインターネットに公開しよう!
+# Engine Yardであなたのアプリをオンラインにあげよう
 
 *Created by Mary Jenn, [@mfjenn](https://twitter.com/mfjenn), Translated by Hiroshi SHIBATA*
 

--- a/_pages/github.md
+++ b/_pages/github.md
@@ -1,10 +1,10 @@
 ---
 layout: main_guide
-title: GitHubにpushしてみよう ( How to Push to GitHub )
+title: GitHub であなたのアプリのコードを公開しよう
 permalink: github
 ---
 
-# GitHubに自分のアプリをPushする
+# GitHub であなたのアプリのコードを公開しよう
 
 *作成者： Alyson La, [@realalysonla](https://www.twitter.com/realalysonla)*
 *[Original page](https://railsgirls.com/)*

--- a/_pages/heroku.md
+++ b/_pages/heroku.md
@@ -1,10 +1,10 @@
 ---
 layout: main_guide
-title: Rails Girls Heroku に deploy
+title: Herokuであなたのアプリをオンラインにあげよう
 permalink: heroku
 ---
 
-# Heroku に Rails アプリを deploy しよう
+# Herokuであなたのアプリをオンラインにあげよう
 
 *Created by Terence Lee, [@hone02](https://twitter.com/hone02)*
 

--- a/_pages/install.md
+++ b/_pages/install.md
@@ -24,8 +24,8 @@ Ruby on Rails でアプリや他のものを作るために、いくつかソフ
 - [Linux 用セットアップ](/install/linux)
 - その他のインストール方法です。上記のガイドでうまくいかなかったら取り組んでみましょう。
     - [仮想マシンにセットアップする](/install/virtual-machine)
-    - [クラウドサービス Replit を使う - 何もインストールする必要はありません](/install/replit)
-    - [GitHub Codespaces を使う](/install/codespaces)
+    - [クラウドサービス Replit を利用する](/install/replit)
+    - [GitHub Codespaces を利用する](/install/codespaces)
 
 {% coach %}
 インストール中に問題が発生した場合、この [Troubleshooting](https://github.com/railsgirls-jp/railsgirls-jp.github.io/wiki/Troubleshooting) のページを参考にしてください。

--- a/_pages/install.md
+++ b/_pages/install.md
@@ -18,7 +18,7 @@ Ruby on Rails でアプリや他のものを作るために、いくつかソフ
 
 一覧にある、あなたのオペレーティングシステムに合った手順に従ってください。何か問題に遭遇しても、慌てないでください。[知られているエラーの節](#possible-errors-during-installation) を確認するか、イベントのオーガナイザーやコーチたちに知らせてください。一緒に解決しましょう。
 
-- [Mac 用セットアップ](/install/macos)
+- [macOS 用セットアップ](/install/macos)
 - [Windows 用セットアップ](/install/windows)
 - [Windows 用セットアップ（WSL）](/install/windows-wsl)
 - [Linux 用セットアップ](/install/linux)

--- a/_pages/install/codespaces.md
+++ b/_pages/install/codespaces.md
@@ -1,11 +1,11 @@
 ---
 layout: main_guide
-title: GitHub Codespaces を使う
+title: GitHub Codespaces を利用する
 description: "Install Ruby and Rails on your Linux computer and get prepared for the Rails Girls workshop."
 permalink: install/codespaces
 ---
 
-# GitHub Codespacesを利用する
+# GitHub Codespaces を利用する
 
 [GitHub Codespaces](https://github.co.jp/features/codespaces) はブラウザ上で開発できるサービスです。必要なものは GitHub アカウントです。無料のプランでも月60時間まで使えるため、有料の Pro プランなどへのアップグレードは不要です。
 

--- a/_pages/install/macos.md
+++ b/_pages/install/macos.md
@@ -1,11 +1,11 @@
 ---
 layout: main_guide
-title: Mac 用セットアップ
+title: macOS 用セットアップ
 description: "Ruby と Rails をあなたの Mac コンピュータにインストールし、Rails Girls ワークショップの準備をしましょう。"
 permalink: install/macos
 ---
 
-# Mac 用セットアップ
+# macOS 用セットアップ
 
 *翻訳者: Goh Matsumoto, [@urimaro](https://twitter.com/urimaro)*
 

--- a/_pages/openshift.md
+++ b/_pages/openshift.md
@@ -1,10 +1,10 @@
 ---
 layout: main_guide
-title: Rails Girls on OpenShift
+title: OpenShiftであなたのアプリをオンラインにあげよう
 permalink: openshift
 ---
 
-# OpenShiftでアプリを公開する
+# OpenShiftであなたのアプリをオンラインにあげよう
 
 *Created by Katie Miller, [@codemiller](https://twitter.com/codemiller) / 翻訳: Uchio Kondo [@udzura](https://github.com/udzura)*
 

--- a/_pages/passenger.md
+++ b/_pages/passenger.md
@@ -1,6 +1,6 @@
 ---
 layout: guide
-title: Rails Girls on Passenger
+title: Phusion Passengerでスムーズに開発しよう
 permalink: passenger
 ---
 

--- a/_pages/ruby-game.md
+++ b/_pages/ruby-game.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Write a little game in Ruby!
+title: Rubyで簡単なゲームを作ってみよう！
 permalink: ruby-game
 ---
 
-# Ruby で簡単なゲームを作ってみよう
+# Rubyで簡単なゲームを作ってみよう！
 
 *Created by Patrick Huesler, [@phuesler](https://twitter.com/phuesler) & Floor Drees, [@floordrees](https://twitter.com/floordrees) for [Rails Girls The Hague](https://railsgirls.com/thehague)*　/ _翻訳者: maimu, [@maimux2x](https://twitter.com/maimux2x)_
 

--- a/_pages/shoulda-matchers.md
+++ b/_pages/shoulda-matchers.md
@@ -1,6 +1,6 @@
 ---
 layout: guide
-title: shoulda matchersでテストを簡潔にしよう
+title: Shoulda Matchersでテストを簡潔にしよう
 permalink: testing-shoulda-matchers
 ---
 

--- a/_pages/sinatra-app-tutorial.md
+++ b/_pages/sinatra-app-tutorial.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Rails Girls Sinatra tutorial
+title: Sinatraを使って初めての投票アプリを作ってみよう
 permalink: sinatra-app
 redirect_from:
   - sinatra-app-bg

--- a/_pages/sinatra.md
+++ b/_pages/sinatra.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Web Fundamentals Tutorial
+title: Web基礎チュートリアル
 permalink: sinatra
 ---
 

--- a/_pages/test-driven-development.md
+++ b/_pages/test-driven-development.md
@@ -1,12 +1,12 @@
 ---
 layout: default
-title: Test Driven Development
+title: テスト駆動開発
 permalink: test-driven-development
 ---
 
 # テスト駆動開発
 
-*Written by Gregory McIntyre, [@gregmcintyre](https://twitter.com/gregmcintyre)*  
+*Written by Gregory McIntyre, [@gregmcintyre](https://twitter.com/gregmcintyre)*
 *Translated by Toshiki Iwama, [@avenue2115](https://twitter.com/avenue2115)*
 
 この演習では、*テスト駆動開発* (TDD)という言葉を使うとき、どのようなことを意図しているのかを学びます。

--- a/_pages/touristic-autism_basic-app.md
+++ b/_pages/touristic-autism_basic-app.md
@@ -9,7 +9,7 @@ permalink: touristic-autism_basic-app
 *Created by Myriam Leggieri, [@iammyr](https://twitter.com/iammyr)*
 *for [Rails Girls Galway](https://github.com/RailsGirlsGalway)*
 
-このガイドでは、[Ruby on Rails Tutorial](https://www.railstutorial.org/book)、[はじめてのアプリを作る](/app)、そして [CarrierWave を使ってサムネイルを作ってみよう](/thumbnails)、[Devise で認証機能を追加](/devise)、[HTML と CSS を使ってアイデアのページをデザインしてみよう](/design)、[OpenShiftでアプリを公開する](/openshift)、[コメント機能を追加しよう](/commenting) のチュートリアルといった基礎的なガイドを統合、適用しています。
+このガイドでは、[Ruby on Rails Tutorial](https://www.railstutorial.org/book)、[はじめてのアプリを作る](/app)、そして [画像のサムネイルを作ってみよう](/thumbnails)、[Deviseによる認証を追加してみよう](/devise)、[HTML と CSS を使ってアイデアのページをデザインしてみよう](/design)、[OpenShiftであなたのアプリをオンラインにあげよう](/openshift)、[コメント機能を追加しよう](/commenting) のチュートリアルといった基礎的なガイドを統合、適用しています。
 
 
 ## ツールを知る

--- a/_pages/touristic-autism_basic-app.md
+++ b/_pages/touristic-autism_basic-app.md
@@ -9,7 +9,7 @@ permalink: touristic-autism_basic-app
 *Created by Myriam Leggieri, [@iammyr](https://twitter.com/iammyr)*
 *for [Rails Girls Galway](https://github.com/RailsGirlsGalway)*
 
-このガイドでは、[Ruby on Rails Tutorial](https://www.railstutorial.org/book)、[はじめてのアプリを作る](/app)、そして [CarrierWave を使ってサムネイルを作ってみよう](/thumbnails)、[Devise で認証機能を追加](/devise)、[HTML & CSS を使ってデザインしてみよう](/design)、[OpenShiftでアプリを公開する](/openshift)、[コメント機能を追加しよう](/commenting) のチュートリアルといった基礎的なガイドを統合、適用しています。
+このガイドでは、[Ruby on Rails Tutorial](https://www.railstutorial.org/book)、[はじめてのアプリを作る](/app)、そして [CarrierWave を使ってサムネイルを作ってみよう](/thumbnails)、[Devise で認証機能を追加](/devise)、[HTML と CSS を使ってアイデアのページをデザインしてみよう](/design)、[OpenShiftでアプリを公開する](/openshift)、[コメント機能を追加しよう](/commenting) のチュートリアルといった基礎的なガイドを統合、適用しています。
 
 
 ## ツールを知る

--- a/_pages/touristic-autism_intro.md
+++ b/_pages/touristic-autism_intro.md
@@ -17,7 +17,7 @@ permalink: touristic-autism_intro
 * 評価機能
 * 認証ユーザー（デバイス経由）の権限設定
 
-このガイドでは、[Ruby on Rails Tutorial](https://www.railstutorial.org/book)、[はじめてのアプリを作る](/app)、そして [CarrierWave を使ってサムネイルを作ってみよう](/thumbnails)、[Devise で認証機能を追加](/devise)、[HTML と CSS を使ってアイデアのページをデザインしてみよう](/design)、[OpenShiftでアプリを公開する](/openshift)、[コメント機能を追加しよう](/commenting) のチュートリアルといった基礎的なガイドを統合、適用しています。
+このガイドでは、[Ruby on Rails Tutorial](https://www.railstutorial.org/book)、[はじめてのアプリを作る](/app)、そして [画像のサムネイルを作ってみよう](/thumbnails)、[Deviseによる認証を追加してみよう](/devise)、[HTML と CSS を使ってアイデアのページをデザインしてみよう](/design)、[OpenShiftであなたのアプリをオンラインにあげよう](/openshift)、[コメント機能を追加しよう](/commenting) のチュートリアルといった基礎的なガイドを統合、適用しています。
 
 
 
@@ -59,7 +59,7 @@ git config --global user.email your.email@example.com
 ## 追加ガイド
 
 * Guide 0: [Ruby、Rails、コンソール、テキストエディタについての便利なチートシート](https://www.pragtob.info/rails-beginner-cheatsheet/)
-* Guide 1: [Heroku に Rails アプリを deploy しよう by Terence Lee](/heroku) / [OpenShiftでアプリを公開する by Katie Miller](/openshift) / [anyninesを使用してインターネットに公開しよう!](/anynines)
+* Guide 1: [Herokuであなたのアプリをオンラインにあげよう by Terence Lee](/heroku) / [OpenShiftであなたのアプリをオンラインにあげよう by Katie Miller](/openshift) / [anyninesであなたのアプリをオンラインにあげよう](/anynines)
 * Guide 2: [Gravatarでプロフィール写真を追加する](/gravatar)
 * Guide 3: [Lucy Bainによるアプリの追加説明を見る](https://github.com/lbain/railsgirls)
 

--- a/_pages/touristic-autism_intro.md
+++ b/_pages/touristic-autism_intro.md
@@ -17,7 +17,7 @@ permalink: touristic-autism_intro
 * 評価機能
 * 認証ユーザー（デバイス経由）の権限設定
 
-このガイドでは、[Ruby on Rails Tutorial](https://www.railstutorial.org/book)、[はじめてのアプリを作る](/app)、そして [CarrierWave を使ってサムネイルを作ってみよう](/thumbnails)、[Devise で認証機能を追加](/devise)、[HTML & CSS を使ってデザインしてみよう](/design)、[OpenShiftでアプリを公開する](/openshift)、[コメント機能を追加しよう](/commenting) のチュートリアルといった基礎的なガイドを統合、適用しています。
+このガイドでは、[Ruby on Rails Tutorial](https://www.railstutorial.org/book)、[はじめてのアプリを作る](/app)、そして [CarrierWave を使ってサムネイルを作ってみよう](/thumbnails)、[Devise で認証機能を追加](/devise)、[HTML と CSS を使ってアイデアのページをデザインしてみよう](/design)、[OpenShiftでアプリを公開する](/openshift)、[コメント機能を追加しよう](/commenting) のチュートリアルといった基礎的なガイドを統合、適用しています。
 
 
 

--- a/_pages/uploads.md
+++ b/_pages/uploads.md
@@ -1,11 +1,11 @@
 ---
 layout: main_guide
-title: 画像アップロード機能を追加する
+title: 画像アップロード機能を追加しよう
 description: "Railsアプリで画像アップロードをできるようにしてアイデアを膨らませよう。"
 permalink: uploads
 ---
 
-# 画像アップロード機能を追加する
+# 画像アップロード機能を追加しよう
 
 *翻訳者: Mai Muta, [@maimux2x](https://twitter.com/maimux2x)*
 

--- a/_posts-jp/install/windows-wsl.md
+++ b/_posts-jp/install/windows-wsl.md
@@ -1,7 +1,7 @@
 ---
 layout: main_guide
-title: Setup on Windows with WSL
-description: "Install Ruby and Rails on your Windows computer and get prepared for the Rails Girls workshop."
+title: Windows 用セットアップ（WSL）
+description: "Ruby と Rails をあなたの Windows コンピュータにインストールし、Rails Girls ワークショップの準備をしましょう。"
 permalink: install/windows-wsl
 ---
 

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@ Rails Girls Japanの<a href="https://twitter.com/RailsGirlsJapan">X(旧Twitter)<
   <li>
     <a href="commenting">
       <span class="guide-icon" data-icon="12"></span>
-      <h3>あなたのアプリにコメント出来るようにしましょう</h3>
+      <h3>コメント機能を追加しよう</h3>
     </a>
     <p>あなたのアプリを見た人がコメントする方法を紹介します。</p>
   </li>

--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@ Rails Girls Japanの<a href="https://twitter.com/RailsGirlsJapan">X(旧Twitter)<
     <p>
       - <a href="continuous-travis">Travis（およびanynines）を使用した継続的デプロイ</a><br>
       - <a href="continuous">Codeship（およびHeroku）を使用した継続的デプロイ</a><br>
-      - <a href="passenger">Phusion Passengerでアプリのデプロイを準備しよう</a><br>
+      - <a href="passenger">Phusion Passengerでスムーズに開発しよう</a><br>
     </p>
   </li>
 

--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@ Rails Girls Japanの<a href="https://twitter.com/RailsGirlsJapan">X(旧Twitter)<
   <li>
     <a href="diary-app">
       <span class="guide-icon guide-icon-other"></span>
-      <h3>Ruby on Railsで初めての日記アプリを作る</h3>
+      <h3>Ruby on Railsで初めての日記アプリを作ろう</h3>
     </a>
     <p>Ruby on Railsを使ったアプリケーションの作成について解説します。</p>
   </li>

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@ Rails Girls Japanの<a href="https://twitter.com/RailsGirlsJapan">X(旧Twitter)<
   <li>
     <a href="install">
       <span class="guide-icon" data-icon="3"></span>
-      <h3>Railsインストールガイド</h3>
+      <h3>Rails Girls インストール・レシピ</h3>
     </a>
     <p>Ruby on Railsでアプリや他の何かを作ろうと思ったら、いくつかのソフトウェアと開発環境をあなたのコンピュータにセットアップする必要があります(macOS, Windows, Linux)。</p>
   </li>
@@ -100,7 +100,7 @@ Rails Girls Japanの<a href="https://twitter.com/RailsGirlsJapan">X(旧Twitter)<
   <li>
     <a href="/new-homepage">
       <span class="guide-icon" data-icon="7"></span>
-      <h3>あなたのアプリに新しいホーム画面を追加しよう</h3>
+      <h3>新しいホーム画面を追加しよう</h3>
     </a>
     <p>あなたのアプリのホーム画面をカスタマイズしましょう。</p>
   </li>


### PR DESCRIPTION
Issue https://github.com/railsgirls-jp/railsgirls.jp/issues/886 に対応しました。

- ページの見出しのタイトルと、ページ下のガイド一覧（_includes/main_guides.md）との表記揺れを修正しました。
  - なるべく表記の仕方を「〜しよう」など元々多かった言い回しに統一しましたが、文言を修正する箇所があればレビューにて教えていただけると幸いです。
- Windows 用セットアップ（WSL）のページ（_posts-jp/install/windows-wsl.md）のFront Matterに英語が残っていたため、翻訳しました。
- 作業中に気になった点について別途Issueを立てました：https://github.com/railsgirls-jp/railsgirls.jp/issues/916