### PR TITLE
Add OGP and Twitter Card meta tags

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,6 +12,20 @@
   <link href="/css/style.css" rel="stylesheet"/>
   <link href="/favicon.png" rel="shortcut icon"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <!-- OGP -->
+  <meta property="og:title" content="{{ page.title | default: site.title }}"/>
+  <meta property="og:url" content="{{ page.url | absolute_url }}"/>
+  {% if page.image %}
+    <meta property="og:image" content="{{ page.image | absolute_url }}"/>
+  {% endif %}
+
+  <!-- Twitter -->
+  {% if page.image %}
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:title" content="{{ page.title }}"/>
+    <meta name="twitter:image" content="{{ page.image | absolute_url }}"/>
+  {% endif %}
 </head>
 <body>
   {% include header.html %}


### PR DESCRIPTION
開催報告レポートなどのBlog記事の共有時にOGPを表示したいと思い追加しました。
ローカル上で、postのFront Matterがheadに正しく反映されていることを確認しました。
以下は、_posts/blog/2025-10-17-railsgirls-sapporo-2nd.markdown の例です。
```html
<head>
  <!-- 〜省略〜 -->

  <!-- OGP -->
  <meta property="og:title" content="Rails Girls Sapporo 2nd 開催レポート">
  <meta property="og:url" content="http://localhost:4000/2025/12/22/railsgirls-sapporo-2nd/">
  <meta property="og:image" content="http://localhost:4000/images/blog/sapporo2nd/syugo.webp">
  
  <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Rails Girls Sapporo 2nd 開催レポート">
   <meta name="twitter:image" content="http://localhost:4000/images/blog/sapporo2nd/syugo.webp">
</head>
```

どなたかレビューいただけますと幸いです🙇