### PR TITLE
Move Tokyo 18th event page to past

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -18,14 +18,15 @@ title: "Rails Girls Events"
   <a href="https://railsgirls.com/nagoya.html" class="span4 event" style="background:url(/images/railsgirls-sq.png) 0px -70px / 100% no-repeat;">
     <h3>Rails Girls Nagoya 7th<small>2026/03/27〜2026/03/28</small></h3>
   </a>
-  <a href="https://railsgirls.com/tokyo-2026-02-13.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_18th_OGP.png) center -20px  / 100% no-repeat;">
-    <h3>Rails Girls Tokyo 18th<small>2026/02/13〜2026/02/14</small></h3>
-  </a>
 </div>
 <!-- ↑直近開催予定のイベントページがある場合にコメントアウトを外して内容を更新 -->
 
 <div id="container-past" class="row clearfix">
   <h2>過去のイベント</h2>
+
+  <a href="https://railsgirls.com/tokyo-2026-02-13.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_18th_OGP.png) center -20px  / 100% no-repeat;">
+    <h3>Rails Girls Tokyo 18th<small>2026/02/13〜2026/02/14</small></h3>
+  </a>
 
   <a href="https://railsgirls.com/sapporo-2nd.html" class="span4 event" style="background: url(/images/events/sapporo_2nd_logo.png) 70px -10px / 55% no-repeat;">
     <h3>Rails Girls Sapporo 2nd<small>2025/10/17〜2025/10/18</small></h3>

--- a/index.html
+++ b/index.html
@@ -37,11 +37,6 @@ title: 日本語版ガイド
       <h3>Rails Girls Nagoya 7th<small>2026/03/27〜2026/03/28</small></h3>
     </div>
   </a>
-  <a href="https://railsgirls.com/tokyo-2026-02-13.html" class="span4 event" style="background:url(/images/events/rails_girls_tokyo_18th_OGP.png) center -20px  / 100% no-repeat;">
-    <div>
-      <h3>Rails Girls Tokyo 18th<small>2026/02/13〜2026/02/14</small></h3>
-    </div>
-  </a>
 </div>
 
 Rails Girls Japanの<a href="https://twitter.com/RailsGirlsJapan">X(旧Twitter)</a>や<a href="https://www.instagram.com/railsgirlsjapan/">Instagram</a>では、日本国内で開催するRails Girlsイベント情報などをお知らせしています！


### PR DESCRIPTION
Rails Girls Tokyo 18回（2026年2月13–14日）が終了したため、「近日開催のイベント」から「過去のイベント」へ移動しました。

| path | before | after |
| - | - | - |
| events/index.html | <img width="1728" height="941" alt="image" src="https://github.com/user-attachments/assets/145881a3-c467-4020-9c54-1646af006580" /> | <img width="1728" height="942" alt="image" src="https://github.com/user-attachments/assets/418853ab-67ab-4e40-80f7-85b92f4aa60f" /> |
| index.html | <img width="1728" height="921" alt="image" src="https://github.com/user-attachments/assets/beedd2b8-9993-4d4a-abbd-973b4e6d4a17" /> | <img width="1728" height="929" alt="image" src="https://github.com/user-attachments/assets/44cc35b5-d2f8-4f32-b17f-68912d727edd" /> |